### PR TITLE
Patches for the Windows port

### DIFF
--- a/win/configure.bat
+++ b/win/configure.bat
@@ -67,6 +67,10 @@ call config.guess.bat
 if %ABI% == ? goto :gotcc
 if %GBITS% == %ABI% goto :gotcc
 :step1
+if exist "%VS110COMNTOOLS%\..\..\VC\vcvarsall.bat" (
+	call "%VS110COMNTOOLS%\..\..\VC\vcvarsall.bat" %VCTARGET%
+	goto :checkcc
+)
 if exist "%VS100COMNTOOLS%\..\..\VC\vcvarsall.bat" (
 	call "%VS100COMNTOOLS%\..\..\VC\vcvarsall.bat" %VCTARGET%
 	goto :checkcc
@@ -112,6 +116,10 @@ if exist "%VS100COMNTOOLS%\..\..\VC\bin\vsyasm.exe" (
 	set YASMEXE="%VS100COMNTOOLS%\..\..\VC\bin\vsyasm.exe"
 	goto :gotyasm
 )
+if exist "%VS110COMNTOOLS%\..\..\VC\bin\vsyasm.exe" (
+	set YASMEXE="%VS110COMNTOOLS%\..\..\VC\bin\vsyasm.exe"
+	goto :gotyasm
+)
 if exist "c:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\BuildCustomizations\vsyasm.exe" (
 	set YASMEXE="c:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\BuildCustomizations\vsyasm.exe"
 	goto :gotyasm
@@ -121,7 +129,8 @@ if exist "%VS90COMNTOOLS%\..\..\VC\bin\yasm.exe" (
 	goto :gotyasm
 )
 echo cant find yasm
-exit /b 1
+rem exit /b 1
+set YASMEXE=noyasm
 :gotyasm
 
 :: set config.params.bat to the settings needed by make etc

--- a/win/make.bat
+++ b/win/make.bat
@@ -105,6 +105,7 @@ for %%X in ( ..\..\mpn\generic\*.c) do (
 	if errorlevel 1 goto :err
 	)
 )
+if %YASMEXE% == noyasm goto :noyasm
 for %%X in ( %MPNPATH% ) do (
 	for %%i in ( ..\..\mpn\%%X\*.asm ) do (
 		%YASMEXE% %YASMFLAG% -I ..\..\mpn\%LOCALDIR% -f %LOCALABI% %%i
@@ -112,6 +113,7 @@ for %%X in ( %MPNPATH% ) do (
 		echo assemblin %%i		
 	)
 )
+:noyasm
 :: dont know what the asm version have so delete them
 del preinv_divrem_1.obj preinv_mod_1.obj divrem_1.obj mod_1.obj divrem_euclidean_qr_1.obj > nul 2>&1
 cl %OPT% -I..\.. ..\..\mpn\generic\divrem_1.c


### PR DESCRIPTION
- win/configure.bat works with Visual Studio 2011 / Visual Studio Express 2012
- win/configure.bat and win/make.bat work when yasm.exe is not present
