### PR TITLE
Fix t-locale.c #define used to avoid a test when using mingw64

### DIFF
--- a/tests/misc/t-locale.c
+++ b/tests/misc/t-locale.c
@@ -75,7 +75,7 @@ main (void)
 
 #else /* ! DLL_EXPORT */
 
-#if ! (defined(__MINGW64__) || (defined(_MSC_VER) && _MSC_VER <= 1500))
+#if ! (defined(__MINGW64_VERSION_MAJOR) || (defined(_MSC_VER) && _MSC_VER <= 1500))
 #if HAVE_LOCALECONV
 #ifdef _MSC_VER
 __GMP_DECLSPEC


### PR DESCRIPTION
The macro __MINGW64_VERSION_MAJOR is defined even when mingw64 is being used to compile 32 bit versions of software with the -m32 switch.

**MINGW64** is only defined while compiling 64 bit output.
