### PR TITLE
Yasm settings fix

### DIFF
--- a/build.vc10/dll_mpir_core2/dll_mpir_core2.vcxproj
+++ b/build.vc10/dll_mpir_core2/dll_mpir_core2.vcxproj
@@ -54,7 +54,6 @@ prebuild core2 x64
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -87,7 +86,6 @@ prebuild core2 x64
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc10/dll_mpir_p3/dll_mpir_p3.vcxproj
+++ b/build.vc10/dll_mpir_p3/dll_mpir_p3.vcxproj
@@ -54,7 +54,6 @@ prebuild p3 Win32
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -87,7 +86,6 @@ prebuild p3 Win32
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc10/lib_mpir_core2/lib_mpir_core2.vcxproj
+++ b/build.vc10/lib_mpir_core2/lib_mpir_core2.vcxproj
@@ -54,7 +54,6 @@ prebuild core2 x64
     <Defines></Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -83,7 +82,6 @@ prebuild core2 x64
     <Defines></Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc10/lib_mpir_p3/lib_mpir_p3.vcxproj
+++ b/build.vc10/lib_mpir_p3/lib_mpir_p3.vcxproj
@@ -54,7 +54,6 @@ prebuild p3 Win32
     <Defines></Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -83,7 +82,6 @@ prebuild p3 Win32
     <Defines></Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc10/mpir_config.py
+++ b/build.vc10/mpir_config.py
@@ -446,7 +446,6 @@ def yasm_options(plat, proj_type, outf):
     <Defines>{0:s}</Defines>
     <IncludePaths>..\..\mpn\x86{1:s}w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
 '''

--- a/build.vc11/dll_mpir_core2/dll_mpir_core2.vcxproj
+++ b/build.vc11/dll_mpir_core2/dll_mpir_core2.vcxproj
@@ -54,7 +54,6 @@ prebuild core2 x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild core2 x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc11/dll_mpir_p3/dll_mpir_p3.vcxproj
+++ b/build.vc11/dll_mpir_p3/dll_mpir_p3.vcxproj
@@ -54,7 +54,6 @@ prebuild p3 Win32
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild p3 Win32
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc11/lib_mpir_core2/lib_mpir_core2.vcxproj
+++ b/build.vc11/lib_mpir_core2/lib_mpir_core2.vcxproj
@@ -55,7 +55,6 @@ prebuild core2 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild core2 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc11/lib_mpir_p3/lib_mpir_p3.vcxproj
+++ b/build.vc11/lib_mpir_p3/lib_mpir_p3.vcxproj
@@ -55,7 +55,6 @@ prebuild p3 Win32
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild p3 Win32
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc11/mpir_config.py
+++ b/build.vc11/mpir_config.py
@@ -448,7 +448,6 @@ def yasm_options(plat, proj_type, outf):
     <Defines>{0:s}</Defines>
     <IncludePaths>..\..\mpn\x86{1:s}w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
 '''

--- a/build.vc12/dll_mpir_core2/dll_mpir_core2.vcxproj
+++ b/build.vc12/dll_mpir_core2/dll_mpir_core2.vcxproj
@@ -54,7 +54,6 @@ prebuild core2 x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild core2 x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/dll_mpir_k8/dll_mpir_k8.vcxproj
+++ b/build.vc12/dll_mpir_k8/dll_mpir_k8.vcxproj
@@ -54,7 +54,6 @@ prebuild k8 x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild k8 x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/dll_mpir_nehalem/dll_mpir_nehalem.vcxproj
+++ b/build.vc12/dll_mpir_nehalem/dll_mpir_nehalem.vcxproj
@@ -54,7 +54,6 @@ prebuild nehalem x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild nehalem x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/dll_mpir_p3/dll_mpir_p3.vcxproj
+++ b/build.vc12/dll_mpir_p3/dll_mpir_p3.vcxproj
@@ -54,7 +54,6 @@ prebuild p3 Win32
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild p3 Win32
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/dll_mpir_sandybridge/dll_mpir_sandybridge.vcxproj
+++ b/build.vc12/dll_mpir_sandybridge/dll_mpir_sandybridge.vcxproj
@@ -54,7 +54,6 @@ prebuild sandybridge x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild sandybridge x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/lib_mpir_core2/lib_mpir_core2.vcxproj
+++ b/build.vc12/lib_mpir_core2/lib_mpir_core2.vcxproj
@@ -55,7 +55,6 @@ prebuild core2 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild core2 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/lib_mpir_k8/lib_mpir_k8.vcxproj
+++ b/build.vc12/lib_mpir_k8/lib_mpir_k8.vcxproj
@@ -55,7 +55,6 @@ prebuild k8 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild k8 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/lib_mpir_nehalem/lib_mpir_nehalem.vcxproj
+++ b/build.vc12/lib_mpir_nehalem/lib_mpir_nehalem.vcxproj
@@ -55,7 +55,6 @@ prebuild nehalem x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild nehalem x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/lib_mpir_p3/lib_mpir_p3.vcxproj
+++ b/build.vc12/lib_mpir_p3/lib_mpir_p3.vcxproj
@@ -55,7 +55,6 @@ prebuild p3 Win32
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild p3 Win32
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/lib_mpir_sandybridge/lib_mpir_sandybridge.vcxproj
+++ b/build.vc12/lib_mpir_sandybridge/lib_mpir_sandybridge.vcxproj
@@ -55,7 +55,6 @@ prebuild sandybridge x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild sandybridge x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc12/mpir_config.py
+++ b/build.vc12/mpir_config.py
@@ -447,7 +447,6 @@ def yasm_options(plat, proj_type, outf):
     <Defines>{0:s}</Defines>
     <IncludePaths>..\..\mpn\x86{1:s}w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
 '''

--- a/build.vc14/dll_mpir_core2/dll_mpir_core2.vcxproj
+++ b/build.vc14/dll_mpir_core2/dll_mpir_core2.vcxproj
@@ -54,7 +54,6 @@ prebuild core2 x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild core2 x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/dll_mpir_haswell/dll_mpir_haswell.vcxproj
+++ b/build.vc14/dll_mpir_haswell/dll_mpir_haswell.vcxproj
@@ -54,7 +54,6 @@ prebuild haswell x64
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -87,7 +86,6 @@ prebuild haswell x64
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/dll_mpir_k8/dll_mpir_k8.vcxproj
+++ b/build.vc14/dll_mpir_k8/dll_mpir_k8.vcxproj
@@ -54,7 +54,6 @@ prebuild k8 x64
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -87,7 +86,6 @@ prebuild k8 x64
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/dll_mpir_nehalem/dll_mpir_nehalem.vcxproj
+++ b/build.vc14/dll_mpir_nehalem/dll_mpir_nehalem.vcxproj
@@ -54,7 +54,6 @@ prebuild nehalem x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild nehalem x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/dll_mpir_p3/dll_mpir_p3.vcxproj
+++ b/build.vc14/dll_mpir_p3/dll_mpir_p3.vcxproj
@@ -54,7 +54,6 @@ prebuild p3 Win32
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -87,7 +86,6 @@ prebuild p3 Win32
     <Defines>DLL</Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/dll_mpir_sandybridge/dll_mpir_sandybridge.vcxproj
+++ b/build.vc14/dll_mpir_sandybridge/dll_mpir_sandybridge.vcxproj
@@ -54,7 +54,6 @@ prebuild sandybridge x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild sandybridge x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/dll_mpir_sandybridge_ivybridge/dll_mpir_sandybridge_ivybridge.vcxproj
+++ b/build.vc14/dll_mpir_sandybridge_ivybridge/dll_mpir_sandybridge_ivybridge.vcxproj
@@ -54,7 +54,6 @@ prebuild sandybridge\ivybridge x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -86,7 +85,6 @@ prebuild sandybridge\ivybridge x64
       <Defines>DLL</Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/lib_mpir_core2/lib_mpir_core2.vcxproj
+++ b/build.vc14/lib_mpir_core2/lib_mpir_core2.vcxproj
@@ -55,7 +55,6 @@ prebuild core2 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild core2 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/lib_mpir_haswell/lib_mpir_haswell.vcxproj
+++ b/build.vc14/lib_mpir_haswell/lib_mpir_haswell.vcxproj
@@ -54,7 +54,6 @@ prebuild haswell x64
     <Defines></Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -83,7 +82,6 @@ prebuild haswell x64
     <Defines></Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/lib_mpir_k8/lib_mpir_k8.vcxproj
+++ b/build.vc14/lib_mpir_k8/lib_mpir_k8.vcxproj
@@ -55,7 +55,6 @@ prebuild k8 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild k8 x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/lib_mpir_nehalem/lib_mpir_nehalem.vcxproj
+++ b/build.vc14/lib_mpir_nehalem/lib_mpir_nehalem.vcxproj
@@ -55,7 +55,6 @@ prebuild nehalem x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild nehalem x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/lib_mpir_p3/lib_mpir_p3.vcxproj
+++ b/build.vc14/lib_mpir_p3/lib_mpir_p3.vcxproj
@@ -54,7 +54,6 @@ prebuild p3 Win32
     <Defines></Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -83,7 +82,6 @@ prebuild p3 Win32
     <Defines></Defines>
     <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/lib_mpir_sandybridge/lib_mpir_sandybridge.vcxproj
+++ b/build.vc14/lib_mpir_sandybridge/lib_mpir_sandybridge.vcxproj
@@ -55,7 +55,6 @@ prebuild sandybridge x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild sandybridge x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/lib_mpir_sandybridge_ivybridge/lib_mpir_sandybridge_ivybridge.vcxproj
+++ b/build.vc14/lib_mpir_sandybridge_ivybridge/lib_mpir_sandybridge_ivybridge.vcxproj
@@ -55,7 +55,6 @@ prebuild sandybridge\ivybridge x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>
@@ -84,7 +83,6 @@ prebuild sandybridge\ivybridge x64
       </Defines>
       <IncludePaths>..\..\mpn\x86_64w\</IncludePaths>
       <Debug>true</Debug>
-      <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
       <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
     <ClCompile>

--- a/build.vc14/mpir_config.py
+++ b/build.vc14/mpir_config.py
@@ -447,7 +447,6 @@ def yasm_options(plat, proj_type, outf):
     <Defines>{0:s}</Defines>
     <IncludePaths>..\..\mpn\x86{1:s}w\</IncludePaths>
     <Debug>true</Debug>
-    <ObjectFileName>$(IntDir)mpn\</ObjectFileName>
     <ObjectFile>$(IntDir)mpn\</ObjectFile>
     </YASM>
 '''


### PR DESCRIPTION
It seems that item YASM/ObjectFileName makes no sence in MSVC projects. It is not mentioned in either vsyasm.xml, vsyasm.props, vsyasm.target, so Studio does not know what  to do with this item.
I suppose that YASM/ObjectFileName was used in the past, but now it obsolete and replaced by YASM/ObjectFile item.

I removed YASM/ObjectFileName from all projects and mpir-config.py
Thank you.
