### PR TITLE
Appveyor fixes

### DIFF
--- a/.appveyor_msys_build.sh
+++ b/.appveyor_msys_build.sh
@@ -1,9 +1,5 @@
-export PATH=/c/msys64/mingw$ABI/bin:$PATH
+export PATH=/c/msys64/mingw$ABI/bin:/c/projects/mpir/bin/:$PATH
 cd /c/projects/mpir
-./configure ABI=$ABI
+./configure ABI=$ABI --with-system-yasm
 make
-if [ "$ABI" = "32" ]
-then
-    rm yasm/Makefile
-fi
 make check

--- a/.appveyor_msys_build.sh
+++ b/.appveyor_msys_build.sh
@@ -2,4 +2,8 @@ export PATH=/c/msys64/mingw$ABI/bin:$PATH
 cd /c/projects/mpir
 ./configure ABI=$ABI
 make
+if [ "$ABI" = "32" ]
+then
+    rm yasm/Makefile
+fi
 make check

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,16 @@ build:
   
 environment:
   matrix:
+    - COMPILER: MinGW-w64
+      ABI: 32
+    - COMPILER: MinGW-w64
+      ABI: 64
     - BUILD_TYPE: Release
       COMPILER: MSVC15
       PLATFORM: x64
     - BUILD_TYPE: Release
       COMPILER: MSVC15
       PLATFORM: Win32
-    - COMPILER: MinGW-w64
-      ABI: 64
-    - COMPILER: MinGW-w64
-      ABI: 32
 #    - BUILD_TYPE: Debug
 #      COMPILER: MSVC15
 #      PLATFORM: x64
@@ -22,6 +22,7 @@ environment:
 #      PLATFORM: Win32
  
 build_script:
+  - if [%COMPILER%]==[MinGW-w64] mkdir bin && cd bin\ && appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -fileName yasm.exe
   - if [%COMPILER%]==[MinGW-w64] C:\msys64\usr\bin\sh.exe --login /c/projects/mpir/.appveyor_msys_build.sh
   - if [%COMPILER%]==[MSVC15] cd build.vc14
   - if [%COMPILER%]==[MSVC15] msbuild.bat gc lib %PLATFORM% %BUILD_TYPE% +tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,12 @@ environment:
       ABI: 64
     - COMPILER: MinGW-w64
       ABI: 32
-    - BUILD_TYPE: Debug
-      COMPILER: MSVC15
-      PLATFORM: x64
-    - BUILD_TYPE: Debug
-      COMPILER: MSVC15
-      PLATFORM: Win32
+#    - BUILD_TYPE: Debug
+#      COMPILER: MSVC15
+#      PLATFORM: x64
+#    - BUILD_TYPE: Debug
+#      COMPILER: MSVC15
+#      PLATFORM: Win32
  
 build_script:
   - if [%COMPILER%]==[MinGW-w64] C:\msys64\usr\bin\sh.exe --login /c/projects/mpir/.appveyor_msys_build.sh


### PR DESCRIPTION
I've removed the debug builds as they take too much time.

MSVC15       - 32 bit and 64 bit
MinGW-w64  - 32 bit and 64 bit

Yasm tests fail for MinGW-w64 32 bit and since I couldn't find a way to stop yasm tests (except for changing yasm files), I've used system-wide yasm.