### PR TITLE
fix compilation with i586-pc-msdosdjgpp (using GCC 4.7.3)

### DIFF
--- a/mpz/inp_str.c
+++ b/mpz/inp_str.c
@@ -144,18 +144,17 @@ mpz_inp_str_nowhite (mpz_ptr x, FILE *stream, int base, int c, size_t nread)
   return nread;
 }
 
-​
 size_t
 mpz_inp_str (mpz_ptr x, FILE *stream, int base)
 {
   int c;
   size_t nread;
-​
+
   if (stream == 0)
     stream = stdin;
-​
+
   nread = 0;
-​
+
   /* Skip whitespace.  */
   do
     {
@@ -163,6 +162,6 @@ mpz_inp_str (mpz_ptr x, FILE *stream, int base)
       nread++;
     }
   while (isspace (c));
-​
+
   return mpz_inp_str_nowhite (x, stream, base, c, nread);
 }

--- a/mpz/inp_str.c
+++ b/mpz/inp_str.c
@@ -33,28 +33,6 @@ MA 02110-1301, USA. */
 extern const unsigned char __gmp_digit_value_tab[];
 #define digit_value_tab __gmp_digit_value_tab
 
-size_t
-mpz_inp_str (mpz_ptr x, FILE *stream, int base)
-{
-  int c;
-  size_t nread;
-
-  if (stream == 0)
-    stream = stdin;
-
-  nread = 0;
-
-  /* Skip whitespace.  */
-  do
-    {
-      c = getc (stream);
-      nread++;
-    }
-  while (isspace (c));
-
-  return mpz_inp_str_nowhite (x, stream, base, c, nread);
-}
-
 /* shared by mpq_inp_str */
 size_t
 mpz_inp_str_nowhite (mpz_ptr x, FILE *stream, int base, int c, size_t nread)
@@ -164,4 +142,27 @@ mpz_inp_str_nowhite (mpz_ptr x, FILE *stream, int base, int c, size_t nread)
     }
   (*__gmp_free_func) (str, alloc_size);
   return nread;
+}
+
+​
+size_t
+mpz_inp_str (mpz_ptr x, FILE *stream, int base)
+{
+  int c;
+  size_t nread;
+​
+  if (stream == 0)
+    stream = stdin;
+​
+  nread = 0;
+​
+  /* Skip whitespace.  */
+  do
+    {
+      c = getc (stream);
+      nread++;
+    }
+  while (isspace (c));
+​
+  return mpz_inp_str_nowhite (x, stream, base, c, nread);
 }


### PR DESCRIPTION
GCC raised a warning "mpz_inp_str_nowhite not defined, defined implicit" and directly afterwards error on the conflicting definition.
I've actually not checked why it is not defined nor why the implicit definition is different - but swapping these two functions lead to a working compilation...