### PR TITLE
Broadwell support

### DIFF
--- a/mpn/x86_64/haswell/avx/and_n.as
+++ b/mpn/x86_64/haswell/avx/and_n.as
@@ -1,0 +1,183 @@
+;  AVX mpn_and_n
+;
+;  Copyright 2017 Jens Nurmann
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;   (rdi,rcx) = (rsi,rcx) and (rdx,rcx)
+
+; There is no initial pointer alignment lead in code below. The argument
+; why not is based on some statistical reasoning and measurement points.
+; All statements below strictly refer to the Intel i6xxx (Skylake) 
+; microarchitecture.
+
+; The function is intended to be used with arbitrary pointer alignment on
+; entry. That is there are 8 possible cases to consider:
+
+; - A: 1 x all pointers mis-aligned (mod 32 byte)
+; - B: 3 x one pointer aligned (mod 32 byte))
+; - C: 3 x two pointers aligned (mod 32 byte)
+; - D: 1 x all pointers aligned (mod 32 byte)
+
+; All sub cases under B show equivalent performance, as do all sub cases of
+; C. B is 7% faster than A, C is 11% faster than A and D is 39% faster than A.
+
+; To do a proper alignment would require a complex decision tree to allways 
+; advance the alignment situation in the best possible manner - e.g. pointer
+; 1 is off by 8 while pointer 2 & 3 are off by 16. To do the alignment
+; requires some arith and at least one branch in the function proloque - a
+; reasonable impact for small sized operands. And all this for a small gain
+; (around 6% all summed up) in the average case.
+
+; In a specific application scenario this might be the wrong choice.
+
+; The execution speed of VMOVDQU is equivalent to VMOVDQA in case of aligned
+; pointers. This may be different for earlier generations of Intel core 
+; architectures like Broadwell, Haswell, ...
+
+; cycles per limb with all operands aligned and in:
+
+;                   LD1$      LD2$
+;   Haswell         ???       ???
+;   Broadwell       ???       ???
+;   Skylake         0.29-0.68 0.34-0.94 (depending on alignment)
+
+%include 'yasm_mac.inc'
+
+; definition according to Linux 64 bit ABI
+
+%define ResP    RDI
+%define Src1P   RSI
+%define Src2P   RDX
+%define Size    RCX
+
+%define SizeD   ECX
+%define SizeB   CL
+
+%define Count   RAX
+%define CountD  EAX
+%define CountB  AL
+
+%define Limb0   R8
+%define Limb0D  R8D
+
+%define QLimb0  YMM0
+
+    align   32
+    BITS    64
+
+GLOBAL_FUNC mpn_and_n
+
+    mov     CountD, 3
+    mov     Limb0, Size
+    sub     Count, Size
+    jnc     .PostGPR            ; dispatch size 0-3 immediately
+
+    mov     SizeD, 3
+    shr     Limb0, 2
+    or      Count, -4
+    sub     Size, Limb0
+    jnc     .PostAVX            ; dispatch size 0, 4, 8 & 12 immediately
+
+	; the code density in the core loop is low - 5.18 byte per instruction
+  .Loop:
+
+    vmovdqu QLimb0, [Src1P]
+    vpand   QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+    vmovdqu QLimb0, [Src1P+32]
+    vpand   QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+    vmovdqu QLimb0, [Src1P+64]
+    vpand   QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+    vmovdqu QLimb0, [Src1P+96]
+    vpand   QLimb0, QLimb0, [Src2P+96]
+    vmovdqu [ResP+96], QLimb0
+
+    add     Src1P, 128
+    add     Src2P, 128
+    add     ResP, 128
+
+  .Check:
+
+    add     Size, 4
+    jnc     .Loop
+
+  .PostAVX:
+
+    mov     Limb0D, 0           ; to allow pointer correction on exit
+    cmp     SizeB, 2            ; fastest way to dispatch values 0-3
+    ja      .PostAVX0
+    je      .PostAVX1
+    jp      .PostAVX2
+
+  .PostAVX3:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+64]
+    vpand   QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+
+  .PostAVX2:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+32]
+    vpand   QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+
+  .PostAVX1:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P]
+    vpand   QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+
+  .PostAVX0:
+
+    add     Src1P, Limb0
+    add     Src2P, Limb0
+    add     ResP, Limb0
+    add     Count, 4
+
+  .PostGPR:
+
+    cmp     CountB, 2           ; fastest way to dispatch values 0-3
+    ja      .Exit
+    je      .PostGPR1
+    jp      .PostGPR2
+
+  .PostGPR3:
+
+    mov     Limb0, [Src1P+16]
+    and     Limb0, [Src2P+16]
+    mov     [ResP+16], Limb0
+
+  .PostGPR2:
+
+    mov     Limb0, [Src1P+8]
+    and     Limb0, [Src2P+8]
+    mov     [ResP+8], Limb0
+
+  .PostGPR1:
+
+    mov     Limb0, [Src1P]
+    and     Limb0, [Src2P]
+    mov     [ResP], Limb0
+
+  .Exit:
+
+    ret
+

--- a/mpn/x86_64/haswell/avx/andn_n.as
+++ b/mpn/x86_64/haswell/avx/andn_n.as
@@ -159,19 +159,19 @@ GLOBAL_FUNC mpn_andn_n
   .PostGPR3:
 
     mov     Limb0, [Src1P+16]
-    andn    Limb0, [Src2P+16]
+    andn    Limb0, Limb0, [Src2P+16]
     mov     [ResP+16], Limb0
 
   .PostGPR2:
 
     mov     Limb0, [Src1P+8]
-    andn    Limb0, [Src2P+8]
+    andn    Limb0, Limb0, [Src2P+8]
     mov     [ResP+8], Limb0
 
   .PostGPR1:
 
     mov     Limb0, [Src1P]
-    andn    Limb0, [Src2P]
+    andn    Limb0, Limb0, [Src2P]
     mov     [ResP], Limb0
 
   .Exit:

--- a/mpn/x86_64/haswell/avx/andn_n.as
+++ b/mpn/x86_64/haswell/avx/andn_n.as
@@ -1,0 +1,179 @@
+;  AVX mpn_andn_n
+;
+;  Copyright 2017 Jens Nurmann
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;   (rdi,rcx) = not(rsi,rcx) and (rdx,rcx)
+
+; There is no initial pointer alignment lead in code below. The argument
+; why not is based on some statistical reasoning and measurement points.
+; All statements below strictly refer to the Intel i6xxx (Skylake) 
+; microarchitecture.
+
+; The function is intended to be used with arbitrary pointer alignment on
+; entry. That is there are 8 possible cases to consider:
+
+; - A: 1 x all pointers mis-aligned (mod 32 byte)
+; - B: 3 x one pointer aligned (mod 32 byte))
+; - C: 3 x two pointers aligned (mod 32 byte)
+; - D: 1 x all pointers aligned (mod 32 byte)
+
+; All sub cases under B show equivalent performance, as do all sub cases of
+; C. B is 7% faster than A, C is 11% faster than A and D is 39% faster than A.
+
+; To do a proper alignment would require a complex decision tree to allways 
+; advance the alignment situation in the best possible manner - e.g. pointer
+; 1 is off by 8 while pointer 2 & 3 are off by 16. To do the alignment
+; requires some arith and at least one branch in the function proloque - a
+; reasonable impact for small sized operands. And all this for a small gain
+; (around 6% all summed up) in the average case.
+
+; In a specific application scenario this might be the wrong choice.
+
+; The execution speed of VMOVDQU is equivalent to VMOVDQA in case of aligned
+; pointers. This may be different for earlier generations of Intel core 
+; architectures like Broadwell, Haswell, ...
+
+; cycles per limb with all operands aligned and in:
+
+;                   LD1$      LD2$
+;   Haswell         ???       ???
+;   Broadwell       ???       ???
+;   Skylake         0.29-0.31 0.39-0.40
+
+%include 'yasm_mac.inc'
+
+; definition according to Linux 64 bit ABI
+
+%define ResP    RDI
+%define Src1P   RSI
+%define Src2P   RDX
+%define Size    RCX
+
+%define SizeD   ECX
+
+%define Count   RAX
+%define CountD  EAX
+
+%define Limb0   R8
+%define Limb0D  R8D
+
+%define QLimb0  YMM0
+
+    align   32
+    BITS    64
+
+GLOBAL_FUNC mpn_andn_n
+
+    mov     CountD, 3
+    mov     Limb0, Size
+    sub     Count, Size
+    jnc     .PostGPR            ; dispatch size 0-3 immediately
+
+    mov     SizeD, 3
+    shr     Limb0, 2
+    or      Count, -4
+    sub     Size, Limb0
+    jnc     .PostAVX            ; dispatch size 4, 8 & 12 immediately
+
+    mov     Limb0D, 128
+
+  .Loop:
+
+    vmovdqu QLimb0, [Src1P]
+    vpandn  QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+    vmovdqu QLimb0, [Src1P+32]
+    vpandn  QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+    vmovdqu QLimb0, [Src1P+64]
+    vpandn  QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+    vmovdqu QLimb0, [Src1P+96]
+    vpandn  QLimb0, QLimb0, [Src2P+96]
+    vmovdqu [ResP+96], QLimb0
+
+    lea     Src1P, [Src1P+Limb0]
+    lea     Src2P, [Src2P+Limb0]
+    lea     ResP, [ResP+Limb0]
+
+    add     Size, 4
+    jnc     .Loop
+
+  .PostAVX:
+
+    mov     Limb0D, 0           ; to allow pointer correction on exit
+    cmp     Size, 2             ; fastest way to dispatch values 0-3
+    ja      .PostAVX0
+    je      .PostAVX1
+    jp      .PostAVX2
+
+  .PostAVX3:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+64]
+    vpandn  QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+
+  .PostAVX2:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+32]
+    vpandn  QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+
+  .PostAVX1:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P]
+    vpandn  QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+
+  .PostAVX0:
+
+    add     Src1P, Limb0
+    add     Src2P, Limb0
+    add     ResP, Limb0
+    add     Count, 4
+
+  .PostGPR:
+
+    cmp     Count, 2            ; fastest way to dispatch values 0-3
+    ja      .Exit
+    je      .PostGPR1
+    jp      .PostGPR2
+
+  .PostGPR3:
+
+    mov     Limb0, [Src1P+16]
+    andn    Limb0, [Src2P+16]
+    mov     [ResP+16], Limb0
+
+  .PostGPR2:
+
+    mov     Limb0, [Src1P+8]
+    andn    Limb0, [Src2P+8]
+    mov     [ResP+8], Limb0
+
+  .PostGPR1:
+
+    mov     Limb0, [Src1P]
+    andn    Limb0, [Src2P]
+    mov     [ResP], Limb0
+
+  .Exit:
+
+    ret

--- a/mpn/x86_64/haswell/avx/ior_n.as
+++ b/mpn/x86_64/haswell/avx/ior_n.as
@@ -1,0 +1,179 @@
+;  AVX mpn_ior_n
+;
+;  Copyright 2017 Jens Nurmann
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;   (rdi,rcx) = (rsi,rcx) ior (rdx,rcx)
+
+; There is no initial pointer alignment lead in code below. The argument
+; why not is based on some statistical reasoning and measurement points.
+; All statements below strictly refer to the Intel i6xxx (Skylake) 
+; microarchitecture.
+
+; The function is intended to be used with arbitrary pointer alignment on
+; entry. That is there are 8 possible cases to consider:
+
+; - A: 1 x all pointers mis-aligned (mod 32 byte)
+; - B: 3 x one pointer aligned (mod 32 byte))
+; - C: 3 x two pointers aligned (mod 32 byte)
+; - D: 1 x all pointers aligned (mod 32 byte)
+
+; All sub cases under B show equivalent performance, as do all sub cases of
+; C. B is 7% faster than A, C is 11% faster than A and D is 39% faster than A.
+
+; To do a proper alignment would require a complex decision tree to allways 
+; advance the alignment situation in the best possible manner - e.g. pointer
+; 1 is off by 8 while pointer 2 & 3 are off by 16. To do the alignment
+; requires some arith and at least one branch in the function proloque - a
+; reasonable impact for small sized operands. And all this for a small gain
+; (around 6% all summed up) in the average case.
+
+; In a specific application scenario this might be the wrong choice.
+
+; The execution speed of VMOVDQU is equivalent to VMOVDQA in case of aligned
+; pointers. This may be different for earlier generations of Intel core 
+; architectures like Broadwell, Haswell, ...
+
+; cycles per limb with all operands aligned and in:
+
+;                   LD1$      LD2$
+;   Haswell         ???       ???
+;   Broadwell       ???       ???
+;   Skylake         0.29-0.31 0.39-0.40
+
+%include 'yasm_mac.inc'
+
+; definition according to Linux 64 bit ABI
+
+%define ResP    RDI
+%define Src1P   RSI
+%define Src2P   RDX
+%define Size    RCX
+
+%define SizeD   ECX
+
+%define Count   RAX
+%define CountD  EAX
+
+%define Limb0   R8
+%define Limb0D  R8D
+
+%define QLimb0  YMM0
+
+    align   32
+    BITS    64
+
+GLOBAL_FUNC mpn_ior_n
+
+    mov     CountD, 3
+    mov     Limb0, Size
+    sub     Count, Size
+    jnc     .PostGPR            ; dispatch size 0-3 immediately
+
+    mov     SizeD, 3
+    shr     Limb0, 2
+    or      Count, -4
+    sub     Size, Limb0
+    jnc     .PostAVX            ; dispatch size 4, 8 & 12 immediately
+
+    mov     Limb0D, 128
+
+  .Loop:
+
+    vmovdqu QLimb0, [Src1P]
+    vpor    QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+    vmovdqu QLimb0, [Src1P+32]
+    vpor    QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+    vmovdqu QLimb0, [Src1P+64]
+    vpor    QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+    vmovdqu QLimb0, [Src1P+96]
+    vpor    QLimb0, QLimb0, [Src2P+96]
+    vmovdqu [ResP+96], QLimb0
+
+    lea     Src1P, [Src1P+Limb0]
+    lea     Src2P, [Src2P+Limb0]
+    lea     ResP, [ResP+Limb0]
+
+    add     Size, 4
+    jnc     .Loop
+
+  .PostAVX:
+
+    mov     Limb0D, 0           ; to allow pointer correction on exit
+    cmp     Size, 2             ; fastest way to dispatch values 0-3
+    ja      .PostAVX0
+    je      .PostAVX1
+    jp      .PostAVX2
+
+  .PostAVX3:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+64]
+    vpor    QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+
+  .PostAVX2:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+32]
+    vpor    QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+
+  .PostAVX1:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P]
+    vpor    QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+
+  .PostAVX0:
+
+    add     Src1P, Limb0
+    add     Src2P, Limb0
+    add     ResP, Limb0
+    add     Count, 4
+
+  .PostGPR:
+
+    cmp     Count, 2            ; fastest way to dispatch values 0-3
+    ja      .Exit
+    je      .PostGPR1
+    jp      .PostGPR2
+
+  .PostGPR3:
+
+    mov     Limb0, [Src1P+16]
+    or      Limb0, [Src2P+16]
+    mov     [ResP+16], Limb0
+
+  .PostGPR2:
+
+    mov     Limb0, [Src1P+8]
+    or      Limb0, [Src2P+8]
+    mov     [ResP+8], Limb0
+
+  .PostGPR1:
+
+    mov     Limb0, [Src1P]
+    or      Limb0, [Src2P]
+    mov     [ResP], Limb0
+
+  .Exit:
+
+    ret

--- a/mpn/x86_64/haswell/avx/iorn_n.as
+++ b/mpn/x86_64/haswell/avx/iorn_n.as
@@ -1,0 +1,185 @@
+;  AVX mpn_iorn_n
+;
+;  Copyright 2017 Jens Nurmann
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;   (rdi,rcx) = not(rsi,rcx) and (rdx,rcx)
+
+; There is no initial pointer alignment lead in code below. The argument
+; why not is based on some statistical reasoning and measurement points.
+; All statements below strictly refer to the Intel i6xxx (Skylake) 
+; microarchitecture.
+
+; The function is intended to be used with arbitrary pointer alignment on
+; entry. That is there are 8 possible cases to consider:
+
+; - A: 1 x all pointers mis-aligned (mod 32 byte)
+; - B: 3 x one pointer aligned (mod 32 byte))
+; - C: 3 x two pointers aligned (mod 32 byte)
+; - D: 1 x all pointers aligned (mod 32 byte)
+
+; All sub cases under B show equivalent performance, as do all sub cases of
+; C. B is 7% faster than A, C is 11% faster than A and D is 39% faster than A.
+
+; To do a proper alignment would require a complex decision tree to allways 
+; advance the alignment situation in the best possible manner - e.g. pointer
+; 1 is off by 8 while pointer 2 & 3 are off by 16. To do the alignment
+; requires some arith and at least one branch in the function proloque - a
+; reasonable impact for small sized operands. And all this for a small gain
+; (around 6% all summed up) in the average case.
+
+; In a specific application scenario this might be the wrong choice.
+
+; The execution speed of VMOVDQU is equivalent to VMOVDQA in case of aligned
+; pointers. This may be different for earlier generations of Intel core 
+; architectures like Broadwell, Haswell, ...
+
+; cycles per limb with all operands aligned and in:
+
+;                   LD1$      LD2$
+;   Haswell         ???       ???
+;   Broadwell       ???       ???
+;   Skylake         0.29-0.31 0.39-0.40
+
+%include 'yasm_mac.inc'
+
+; definition according to Linux 64 bit ABI
+
+%define ResP    RDI
+%define Src1P   RSI
+%define Src2P   RDX
+%define Size    RCX
+
+%define SizeD   ECX
+
+%define Count   RAX
+%define CountD  EAX
+
+%define Limb0   R8
+%define Limb0D  R8D
+
+%define QLimb0  YMM0
+%define	QLimb1  YMM1
+
+    align   32
+    BITS    64
+
+GLOBAL_FUNC mpn_iorn_n
+
+    mov     CountD, 3
+    mov     Limb0, Size
+    sub     Count, Size
+    jnc     .PostGPR            ; dispatch size 0-3 immediately
+
+    vpcmpeqq QLimb1, QLimb1, QLimb1
+
+    mov     SizeD, 3
+    shr     Limb0, 2
+    or      Count, -4
+    sub     Size, Limb0
+    jnc     .PostAVX            ; dispatch size 4, 8 & 12 immediately
+
+    mov     Limb0D, 128
+
+  .Loop:
+
+    vpxor   QLimb0, QLimb1, [Src1P]
+    vpor    QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+    vpxor   QLimb0, QLimb1, [Src1P+32]
+    vpor    QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+    vpxor   QLimb0, QLimb1, [Src1P+64]
+    vpor    QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+    vpxor   QLimb0, QLimb1, [Src1P+96]
+    vpor    QLimb0, QLimb0, [Src2P+96]
+    vmovdqu [ResP+96], QLimb0
+
+    lea     Src1P, [Src1P+Limb0]
+    lea     Src2P, [Src2P+Limb0]
+    lea     ResP, [ResP+Limb0]
+
+    add     Size, 4
+    jnc     .Loop
+
+  .PostAVX:
+
+    mov     Limb0D, 0           ; to allow pointer correction on exit
+    cmp     Size, 2             ; fastest way to dispatch values 0-3
+    ja      .PostAVX0
+    je      .PostAVX1
+    jp      .PostAVX2
+
+  .PostAVX3:
+
+    add     Limb0, 32
+    vpxor   QLimb0, QLimb1, [Src1P+64]
+    vpor    QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+
+  .PostAVX2:
+
+    add     Limb0, 32
+    vpxor   QLimb0, QLimb1, [Src1P+32]
+    vpor    QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+
+  .PostAVX1:
+
+    add     Limb0, 32
+    vpxor   QLimb0, QLimb1, [Src1P]
+    vpor    QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+
+  .PostAVX0:
+
+    add     Src1P, Limb0
+    add     Src2P, Limb0
+    add     ResP, Limb0
+    add     Count, 4
+
+  .PostGPR:
+
+    cmp     Count, 2            ; fastest way to dispatch values 0-3
+    ja      .Exit
+    je      .PostGPR1
+    jp      .PostGPR2
+
+  .PostGPR3:
+
+    mov     Limb0, [Src1P+16]
+    not     Limb0
+    or      Limb0, [Src2P+16]
+    mov     [ResP+16], Limb0
+
+  .PostGPR2:
+
+    mov     Limb0, [Src1P+8]
+    not     Limb0
+    or      Limb0, [Src2P+8]
+    mov     [ResP+8], Limb0
+
+  .PostGPR1:
+
+    mov     Limb0, [Src1P]
+    not     Limb0
+    or      Limb0, [Src2P]
+    mov     [ResP], Limb0
+
+  .Exit:
+
+    ret

--- a/mpn/x86_64/haswell/avx/nand_n.as
+++ b/mpn/x86_64/haswell/avx/nand_n.as
@@ -1,0 +1,192 @@
+;  AVX mpn_nand_n
+;
+;  Copyright 2017 Jens Nurmann
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;   (rdi,rcx) = not( (rsi,rcx) and (rdx,rcx) )
+
+; There is no initial pointer alignment lead in code below. The argument
+; why not is based on some statistical reasoning and measurement points.
+; All statements below strictly refer to the Intel i6xxx (Skylake) 
+; microarchitecture.
+
+; The function is intended to be used with arbitrary pointer alignment on
+; entry. That is there are 8 possible cases to consider:
+
+; - A: 1 x all pointers mis-aligned (mod 32 byte)
+; - B: 3 x one pointer aligned (mod 32 byte))
+; - C: 3 x two pointers aligned (mod 32 byte)
+; - D: 1 x all pointers aligned (mod 32 byte)
+
+; All sub cases under B show equivalent performance, as do all sub cases of
+; C. B is 7% faster than A, C is 11% faster than A and D is 39% faster than A.
+
+; To do a proper alignment would require a complex decision tree to allways 
+; advance the alignment situation in the best possible manner - e.g. pointer
+; 1 is off by 8 while pointer 2 & 3 are off by 16. To do the alignment
+; requires some arith and at least one branch in the function proloque - a
+; reasonable impact for small sized operands. And all this for a small gain
+; (around 6% all summed up) in the average case.
+
+; In a specific application scenario this might be the wrong choice.
+
+; The execution speed of VMOVDQU is equivalent to VMOVDQA in case of aligned
+; pointers. This may be different for earlier generations of Intel core 
+; architectures like Broadwell, Haswell, ...
+
+; cycles per limb with all operands aligned and in:
+
+;                   LD1$      LD2$
+;   Haswell         ???       ???
+;   Broadwell       ???       ???
+;   Skylake         0.34-0.35 0.39-0.40
+
+%include 'yasm_mac.inc'
+
+; definition according to Linux 64 bit ABI
+
+%define ResP    RDI
+%define Src1P   RSI
+%define Src2P   RDX
+%define Size    RCX
+
+%define SizeD   ECX
+
+%define Count   RAX
+%define CountD  EAX
+
+%define Limb0   R8
+%define Limb0D  R8D
+
+%define QLimb0  YMM0
+%define QLimb1  YMM1
+
+    align   32
+    BITS    64
+
+GLOBAL_FUNC mpn_nand_n
+
+    mov     CountD, 3
+    mov     Limb0, Size
+    sub     Count, Size
+    jnc     .PostGPR            ; dispatch size 0-3 immediately
+
+    vpcmpeqq QLimb1, QLimb1, QLimb1
+
+    mov     SizeD, 3
+    shr     Limb0, 2
+    or      Count, -4
+    sub     Size, Limb0
+    jnc     .PostAVX            ; dispatch size 4, 8 & 12 immediately
+
+    mov     Limb0D, 128
+
+  .Loop:
+
+    vmovdqu QLimb0, [Src1P]
+    vpand   QLimb0, QLimb0, [Src2P]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP], QLimb0
+    vmovdqu QLimb0, [Src1P+32]
+    vpand   QLimb0, QLimb0, [Src2P+32]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+32], QLimb0
+    vmovdqu QLimb0, [Src1P+64]
+    vpand   QLimb0, QLimb0, [Src2P+64]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+64], QLimb0
+    vmovdqu QLimb0, [Src1P+96]
+    vpand   QLimb0, QLimb0, [Src2P+96]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+96], QLimb0
+
+    lea     Src1P, [Src1P+Limb0]
+    lea     Src2P, [Src2P+Limb0]
+    lea     ResP, [ResP+Limb0]
+
+    add     Size, 4
+    jnc     .Loop
+
+  .PostAVX:
+
+    mov     Limb0D, 0           ; to allow pointer correction on exit
+    cmp     Size, 2             ; fastest way to dispatch values 0-3
+    ja      .PostAVX0
+    je      .PostAVX1
+    jp      .PostAVX2
+
+  .PostAVX3:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+64]
+    vpand   QLimb0, QLimb0, [Src2P+64]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+64], QLimb0
+
+  .PostAVX2:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+32]
+    vpand   QLimb0, QLimb0, [Src2P+32]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+32], QLimb0
+
+  .PostAVX1:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P]
+    vpand   QLimb0, QLimb0, [Src2P]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP], QLimb0
+
+  .PostAVX0:
+
+    add     Src1P, Limb0
+    add     Src2P, Limb0
+    add     ResP, Limb0
+    add     Count, 4
+
+  .PostGPR:
+
+    cmp     Count, 2            ; fastest way to dispatch values 0-3
+    ja      .Exit
+    je      .PostGPR1
+    jp      .PostGPR2
+
+  .PostGPR3:
+
+    mov     Limb0, [Src1P+16]
+    and     Limb0, [Src2P+16]
+    not     Limb0
+    mov     [ResP+16], Limb0
+
+  .PostGPR2:
+
+    mov     Limb0, [Src1P+8]
+    and     Limb0, [Src2P+8]
+    not     Limb0
+    mov     [ResP+8], Limb0
+
+  .PostGPR1:
+
+    mov     Limb0, [Src1P]
+    and     Limb0, [Src2P]
+    not     Limb0
+    mov     [ResP], Limb0
+
+  .Exit:
+
+    ret

--- a/mpn/x86_64/haswell/avx/nior_n.as
+++ b/mpn/x86_64/haswell/avx/nior_n.as
@@ -1,0 +1,192 @@
+;  AVX mpn_nior_n
+;
+;  Copyright 2017 Jens Nurmann
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;   (rdi,rcx) = not( (rsi,rcx) or (rdx,rcx) )
+
+; There is no initial pointer alignment lead in code below. The argument
+; why not is based on some statistical reasoning and measurement points.
+; All statements below strictly refer to the Intel i6xxx (Skylake) 
+; microarchitecture.
+
+; The function is intended to be used with arbitrary pointer alignment on
+; entry. That is there are 8 possible cases to consider:
+
+; - A: 1 x all pointers mis-aligned (mod 32 byte)
+; - B: 3 x one pointer aligned (mod 32 byte))
+; - C: 3 x two pointers aligned (mod 32 byte)
+; - D: 1 x all pointers aligned (mod 32 byte)
+
+; All sub cases under B show equivalent performance, as do all sub cases of
+; C. B is 7% faster than A, C is 11% faster than A and D is 39% faster than A.
+
+; To do a proper alignment would require a complex decision tree to allways 
+; advance the alignment situation in the best possible manner - e.g. pointer
+; 1 is off by 8 while pointer 2 & 3 are off by 16. To do the alignment
+; requires some arith and at least one branch in the function proloque - a
+; reasonable impact for small sized operands. And all this for a small gain
+; (around 6% all summed up) in the average case.
+
+; In a specific application scenario this might be the wrong choice.
+
+; The execution speed of VMOVDQU is equivalent to VMOVDQA in case of aligned
+; pointers. This may be different for earlier generations of Intel core 
+; architectures like Broadwell, Haswell, ...
+
+; cycles per limb with all operands aligned and in:
+
+;                   LD1$      LD2$
+;   Haswell         ???       ???
+;   Broadwell       ???       ???
+;   Skylake         0.34-0.35 0.39-0.40
+
+%include 'yasm_mac.inc'
+
+; definition according to Linux 64 bit ABI
+
+%define ResP    RDI
+%define Src1P   RSI
+%define Src2P   RDX
+%define Size    RCX
+
+%define SizeD   ECX
+
+%define Count   RAX
+%define CountD  EAX
+
+%define Limb0   R8
+%define Limb0D  R8D
+
+%define QLimb0  YMM0
+%define QLimb1  YMM1
+
+    align   32
+    BITS    64
+
+GLOBAL_FUNC mpn_nior_n
+
+    mov     CountD, 3
+    mov     Limb0, Size
+    sub     Count, Size
+    jnc     .PostGPR            ; dispatch size 0-3 immediately
+
+    vpcmpeqq QLimb1, QLimb1, QLimb1
+
+    mov     SizeD, 3
+    shr     Limb0, 2
+    or      Count, -4
+    sub     Size, Limb0
+    jnc     .PostAVX            ; dispatch size 4, 8 & 12 immediately
+
+    mov     Limb0D, 128
+
+  .Loop:
+
+    vmovdqu QLimb0, [Src1P]
+    vpor    QLimb0, QLimb0, [Src2P]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP], QLimb0
+    vmovdqu QLimb0, [Src1P+32]
+    vpor    QLimb0, QLimb0, [Src2P+32]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+32], QLimb0
+    vmovdqu QLimb0, [Src1P+64]
+    vpor    QLimb0, QLimb0, [Src2P+64]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+64], QLimb0
+    vmovdqu QLimb0, [Src1P+96]
+    vpor    QLimb0, QLimb0, [Src2P+96]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+96], QLimb0
+
+    lea     Src1P, [Src1P+Limb0]
+    lea     Src2P, [Src2P+Limb0]
+    lea     ResP, [ResP+Limb0]
+
+    add     Size, 4
+    jnc     .Loop
+
+  .PostAVX:
+
+    mov     Limb0D, 0           ; to allow pointer correction on exit
+    cmp     Size, 2             ; fastest way to dispatch values 0-3
+    ja      .PostAVX0
+    je      .PostAVX1
+    jp      .PostAVX2
+
+  .PostAVX3:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+64]
+    vpor    QLimb0, QLimb0, [Src2P+64]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+64], QLimb0
+
+  .PostAVX2:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+32]
+    vpor    QLimb0, QLimb0, [Src2P+32]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP+32], QLimb0
+
+  .PostAVX1:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P]
+    vpor    QLimb0, QLimb0, [Src2P]
+    vpxor   QLimb0, QLimb0, QLimb1
+    vmovdqu [ResP], QLimb0
+
+  .PostAVX0:
+
+    add     Src1P, Limb0
+    add     Src2P, Limb0
+    add     ResP, Limb0
+    add     Count, 4
+
+  .PostGPR:
+
+    cmp     Count, 2            ; fastest way to dispatch values 0-3
+    ja      .Exit
+    je      .PostGPR1
+    jp      .PostGPR2
+
+  .PostGPR3:
+
+    mov     Limb0, [Src1P+16]
+    or      Limb0, [Src2P+16]
+    not     Limb0
+    mov     [ResP+16], Limb0
+
+  .PostGPR2:
+
+    mov     Limb0, [Src1P+8]
+    or      Limb0, [Src2P+8]
+    not     Limb0
+    mov     [ResP+8], Limb0
+
+  .PostGPR1:
+
+    mov     Limb0, [Src1P]
+    or      Limb0, [Src2P]
+    not     Limb0
+    mov     [ResP], Limb0
+
+  .Exit:
+
+    ret

--- a/mpn/x86_64/haswell/avx/xnor_n.as
+++ b/mpn/x86_64/haswell/avx/xnor_n.as
@@ -1,0 +1,185 @@
+;  AVX mpn_xnor_n
+;
+;  Copyright 2017 Jens Nurmann
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;   (rdi,rcx) = not(rsi,rcx) xor (rdx,rcx)
+
+; There is no initial pointer alignment lead in code below. The argument
+; why not is based on some statistical reasoning and measurement points.
+; All statements below strictly refer to the Intel i6xxx (Skylake) 
+; microarchitecture.
+
+; The function is intended to be used with arbitrary pointer alignment on
+; entry. That is there are 8 possible cases to consider:
+
+; - A: 1 x all pointers mis-aligned (mod 32 byte)
+; - B: 3 x one pointer aligned (mod 32 byte))
+; - C: 3 x two pointers aligned (mod 32 byte)
+; - D: 1 x all pointers aligned (mod 32 byte)
+
+; All sub cases under B show equivalent performance, as do all sub cases of
+; C. B is 7% faster than A, C is 11% faster than A and D is 39% faster than A.
+
+; To do a proper alignment would require a complex decision tree to allways 
+; advance the alignment situation in the best possible manner - e.g. pointer
+; 1 is off by 8 while pointer 2 & 3 are off by 16. To do the alignment
+; requires some arith and at least one branch in the function proloque - a
+; reasonable impact for small sized operands. And all this for a small gain
+; (around 6% all summed up) in the average case.
+
+; In a specific application scenario this might be the wrong choice.
+
+; The execution speed of VMOVDQU is equivalent to VMOVDQA in case of aligned
+; pointers. This may be different for earlier generations of Intel core 
+; architectures like Broadwell, Haswell, ...
+
+; cycles per limb with all operands aligned and in:
+
+;                   LD1$      LD2$
+;   Haswell         ???       ???
+;   Broadwell       ???       ???
+;   Skylake         0.29-0.31 0.39-0.40
+
+%include 'yasm_mac.inc'
+
+; definition according to Linux 64 bit ABI
+
+%define ResP    RDI
+%define Src1P   RSI
+%define Src2P   RDX
+%define Size    RCX
+
+%define SizeD   ECX
+
+%define Count   RAX
+%define CountD  EAX
+
+%define Limb0   R8
+%define Limb0D  R8D
+
+%define QLimb0  YMM0
+%define	QLimb1  YMM1
+
+    align   32
+    BITS    64
+
+GLOBAL_FUNC mpn_xnor_n
+
+    mov     CountD, 3
+    mov     Limb0, Size
+    sub     Count, Size
+    jnc     .PostGPR            ; dispatch size 0-3 immediately
+
+    vpcmpeqq QLimb1, QLimb1, QLimb1
+
+    mov     SizeD, 3
+    shr     Limb0, 2
+    or      Count, -4
+    sub     Size, Limb0
+    jnc     .PostAVX            ; dispatch size 4, 8 & 12 immediately
+
+    mov     Limb0D, 128
+
+  .Loop:
+
+    vpxor   QLimb0, QLimb1, [Src1P]
+    vpxor   QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+    vpxor   QLimb0, QLimb1, [Src1P+32]
+    vpxor   QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+    vpxor   QLimb0, QLimb1, [Src1P+64]
+    vpxor   QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+    vpxor   QLimb0, QLimb1, [Src1P+96]
+    vpxor   QLimb0, QLimb0, [Src2P+96]
+    vmovdqu [ResP+96], QLimb0
+
+    lea     Src1P, [Src1P+Limb0]
+    lea     Src2P, [Src2P+Limb0]
+    lea     ResP, [ResP+Limb0]
+
+    add     Size, 4
+    jnc     .Loop
+
+  .PostAVX:
+
+    mov     Limb0D, 0           ; to allow pointer correction on exit
+    cmp     Size, 2             ; fastest way to dispatch values 0-3
+    ja      .PostAVX0
+    je      .PostAVX1
+    jp      .PostAVX2
+
+  .PostAVX3:
+
+    add     Limb0, 32
+    vpxor   QLimb0, QLimb1, [Src1P+64]
+    vpxor   QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+
+  .PostAVX2:
+
+    add     Limb0, 32
+    vpxor   QLimb0, QLimb1, [Src1P+32]
+    vpxor   QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+
+  .PostAVX1:
+
+    add     Limb0, 32
+    vpxor   QLimb0, QLimb1, [Src1P]
+    vpxor   QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+
+  .PostAVX0:
+
+    add     Src1P, Limb0
+    add     Src2P, Limb0
+    add     ResP, Limb0
+    add     Count, 4
+
+  .PostGPR:
+
+    cmp     Count, 2            ; fastest way to dispatch values 0-3
+    ja      .Exit
+    je      .PostGPR1
+    jp      .PostGPR2
+
+  .PostGPR3:
+
+    mov     Limb0, [Src1P+16]
+    not     Limb0
+    xor     Limb0, [Src2P+16]
+    mov     [ResP+16], Limb0
+
+  .PostGPR2:
+
+    mov     Limb0, [Src1P+8]
+    not     Limb0
+    xor     Limb0, [Src2P+8]
+    mov     [ResP+8], Limb0
+
+  .PostGPR1:
+
+    mov     Limb0, [Src1P]
+    not     Limb0
+    xor     Limb0, [Src2P]
+    mov     [ResP], Limb0
+
+  .Exit:
+
+    ret

--- a/mpn/x86_64/haswell/avx/xor_n.as
+++ b/mpn/x86_64/haswell/avx/xor_n.as
@@ -1,0 +1,179 @@
+;  AVX mpn_xor_n
+;
+;  Copyright 2017 Jens Nurmann
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;   (rdi,rcx) = (rsi,rcx) xor (rdx,rcx)
+
+; There is no initial pointer alignment lead in code below. The argument
+; why not is based on some statistical reasoning and measurement points.
+; All statements below strictly refer to the Intel i6xxx (Skylake) 
+; microarchitecture.
+
+; The function is intended to be used with arbitrary pointer alignment on
+; entry. That is there are 8 possible cases to consider:
+
+; - A: 1 x all pointers mis-aligned (mod 32 byte)
+; - B: 3 x one pointer aligned (mod 32 byte))
+; - C: 3 x two pointers aligned (mod 32 byte)
+; - D: 1 x all pointers aligned (mod 32 byte)
+
+; All sub cases under B show equivalent performance, as do all sub cases of
+; C. B is 7% faster than A, C is 11% faster than A and D is 39% faster than A.
+
+; To do a proper alignment would require a complex decision tree to allways 
+; advance the alignment situation in the best possible manner - e.g. pointer
+; 1 is off by 8 while pointer 2 & 3 are off by 16. To do the alignment
+; requires some arith and at least one branch in the function proloque - a
+; reasonable impact for small sized operands. And all this for a small gain
+; (around 6% all summed up) in the average case.
+
+; In a specific application scenario this might be the wrong choice.
+
+; The execution speed of VMOVDQU is equivalent to VMOVDQA in case of aligned
+; pointers. This may be different for earlier generations of Intel core 
+; architectures like Broadwell, Haswell, ...
+
+; cycles per limb with all operands aligned and in:
+
+;                   LD1$      LD2$
+;   Haswell         ???       ???
+;   Broadwell       ???       ???
+;   Skylake         0.29-0.31 0.39-0.40
+
+%include 'yasm_mac.inc'
+
+; definition according to Linux 64 bit ABI
+
+%define ResP    RDI
+%define Src1P   RSI
+%define Src2P   RDX
+%define Size    RCX
+
+%define SizeD   ECX
+
+%define Count   RAX
+%define CountD  EAX
+
+%define Limb0   R8
+%define Limb0D  R8D
+
+%define QLimb0  YMM0
+
+    align   32
+    BITS    64
+
+GLOBAL_FUNC mpn_xor_n
+
+    mov     CountD, 3
+    mov     Limb0, Size
+    sub     Count, Size
+    jnc     .PostGPR            ; dispatch size 0-3 immediately
+
+    mov     SizeD, 3
+    shr     Limb0, 2
+    or      Count, -4
+    sub     Size, Limb0
+    jnc     .PostAVX            ; dispatch size 4, 8 & 12 immediately
+
+    mov     Limb0D, 128
+
+  .Loop:
+
+    vmovdqu QLimb0, [Src1P]
+    vpxor   QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+    vmovdqu QLimb0, [Src1P+32]
+    vpxor   QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+    vmovdqu QLimb0, [Src1P+64]
+    vpxor   QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+    vmovdqu QLimb0, [Src1P+96]
+    vpxor   QLimb0, QLimb0, [Src2P+96]
+    vmovdqu [ResP+96], QLimb0
+
+    lea     Src1P, [Src1P+Limb0]
+    lea     Src2P, [Src2P+Limb0]
+    lea     ResP, [ResP+Limb0]
+
+    add     Size, 4
+    jnc     .Loop
+
+  .PostAVX:
+
+    mov     Limb0D, 0           ; to allow pointer correction on exit
+    cmp     Size, 2             ; fastest way to dispatch values 0-3
+    ja      .PostAVX0
+    je      .PostAVX1
+    jp      .PostAVX2
+
+  .PostAVX3:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+64]
+    vpxor   QLimb0, QLimb0, [Src2P+64]
+    vmovdqu [ResP+64], QLimb0
+
+  .PostAVX2:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P+32]
+    vpxor   QLimb0, QLimb0, [Src2P+32]
+    vmovdqu [ResP+32], QLimb0
+
+  .PostAVX1:
+
+    add     Limb0, 32
+    vmovdqu QLimb0, [Src1P]
+    vpxor   QLimb0, QLimb0, [Src2P]
+    vmovdqu [ResP], QLimb0
+
+  .PostAVX0:
+
+    add     Src1P, Limb0
+    add     Src2P, Limb0
+    add     ResP, Limb0
+    add     Count, 4
+
+  .PostGPR:
+
+    cmp     Count, 2            ; fastest way to dispatch values 0-3
+    ja      .Exit
+    je      .PostGPR1
+    jp      .PostGPR2
+
+  .PostGPR3:
+
+    mov     Limb0, [Src1P+16]
+    xor     Limb0, [Src2P+16]
+    mov     [ResP+16], Limb0
+
+  .PostGPR2:
+
+    mov     Limb0, [Src1P+8]
+    xor     Limb0, [Src2P+8]
+    mov     [ResP+8], Limb0
+
+  .PostGPR1:
+
+    mov     Limb0, [Src1P]
+    xor     Limb0, [Src2P]
+    mov     [ResP], Limb0
+
+  .Exit:
+
+    ret


### PR DESCRIPTION
- [x] Firstly, there is the attached file LogOps.zip, which contains assembly for logops for Haswell, Broadwell and Skylake. In addition, and_n.as was missing from the original zip file and is also attached to this post. (Added the files here)

- [ ] They all require AVX, so we need to ensure they go in the x86_64/haswell/avx folder and that broadwell and skylake both look in there too (I think both support AVX, but this should be checked).

- [ ] Then the interfaces need to be checked. In fact, I have a note saying that that " In MPIR these implement the functions as A OP NOT B, whereas you use the
definition NOT A OP B." This means the source registers probably have to be swapped. This probably applies to at least andn and iorn.

- [ ] There may also be files in the GMP project that are for Broadwell (we've already made use of their Skylake and Haswell optimisations, as of about March 2017, so look for anything more recent than that, or for Broadwell specifically). Note that not every file in GMP is a drop-in replacement for an equivalent MPIR file. Sometimes we use a slightly different interface, and this needs to be checked. They also use some macros which we don't have defined, in mpn/x86_64/x86_64-defs.m4.

- [ ] First we need to determine if any of the new code is faster than what was already there. You should use the speed program for this:
```
cd tune
make speed
./speed
```
The latter will tell you how to use it. It gives you approximate cycle timings, say from 1-100 limbs. Look for any stalls (big jumps in timings) and report to Jens if they exist (I can pass on the info if we can figure out what is causing any stalls).

As Intel timing is dicky these days, you will want to run speed many times. Some machines don't become stable until they are running at TDP, which can take 150s on some machines (usually it's 2-15 seconds). Make sure hyperthreading is off and the machine is not under heavy load.

- [ ] The GMP project might by now have a better version of the speed program, which may do more accurate timings. I believe they were updating it last we checked, since they were having the same timing issues we were.

- [ ] Be *absolutely fastidious* about preserving copyright notices from any GMP code, and ensuring the AUTHORS file and Contributors section of the documentation is correct, and that credit is given to the GMP Developers on the Website and any release announcements if any new code is used from the GMP project for the release.

- [ ] Next, the functions will need to be individually tested for approx. a few hours each:
```
cd tests/devel
make try
./try
```
It will tell you how to use it.

- [ ] Once everything is finalised, check that the fat build works (--enable-fat configure option).

- [ ] Ensure make check passes as normal and fat build.
