### PR TITLE
fix gmp.h to not use undefined macros for __GMP_DECLSPEC

### DIFF
--- a/gmp-h.in
+++ b/gmp-h.in
@@ -168,18 +168,18 @@ along with the GNU MP Library.  If not, see http://www.gnu.org/licenses/.  */
 #if defined (__GNUC__)
 #define __GMP_DECLSPEC_EXPORT  __declspec(__dllexport__)
 #define __GMP_DECLSPEC_IMPORT  __declspec(__dllimport__)
-#endif
-#if defined (_MSC_VER) || defined (__BORLANDC__)
+#elif defined (_MSC_VER) || defined (__BORLANDC__) || defined (__ORANGEC__)
 #define __GMP_DECLSPEC_EXPORT  __declspec(dllexport)
 #define __GMP_DECLSPEC_IMPORT  __declspec(dllimport)
-#endif
-#ifdef __WATCOMC__
+#elif defined (__WATCOMC__)
 #define __GMP_DECLSPEC_EXPORT  __export
 #define __GMP_DECLSPEC_IMPORT  __import
-#endif
-#ifdef __IBMC__
+#elif defined (__IBMC__)
 #define __GMP_DECLSPEC_EXPORT  _Export
 #define __GMP_DECLSPEC_IMPORT  _Import
+#else
+#define __GMP_DECLSPEC_EXPORT
+#define __GMP_DECLSPEC_IMPORT
 #endif
 
 #if defined( _MSC_VER )


### PR DESCRIPTION
When `__GMP_LIBGMP_DLL` is defined `__GMP_DECLSPEC` is defined for import/export using another macros which are not always defined.

The proposed change defines them empty when the compiler is not known and adds the working definition for the OrangeC compiler.