### PR TITLE
Add support for non-AVX Haswell CPU models

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -44,7 +44,7 @@ define(X86_PATTERN,
 [[i?86*-*-* | k[5-8]*-*-* | pentium*-*-* | prescott-*-* | core-*-* | athlon-*-* | viac3*-*-*]])
 
 define(X86_64_PATTERN,
-[[x86_64-*-* | netburst-*-* | netburstlahf-*-* | k8-*-* | k10-*-* | k102-*-* | k103-*-* | core2-*-* | penryn-*-* | nehalem-*-* | westmere-*-* | sandybridge-*-* | atom-*-* | nano-*-* | bobcat-*-* | bulldozer-*-* | piledriver-*-* | ivybridge-*-* | haswell-*-*  | broadwell-*-* | skylake-*-* | skylakeavx-*-*]])
+[[x86_64-*-* | netburst-*-* | netburstlahf-*-* | k8-*-* | k10-*-* | k102-*-* | k103-*-* | core2-*-* | penryn-*-* | nehalem-*-* | westmere-*-* | sandybridge-*-* | atom-*-* | nano-*-* | bobcat-*-* | bulldozer-*-* | piledriver-*-* | ivybridge-*-* | haswell-*-*  | haswellavx-*-* | broadwell-*-* | skylake-*-* | skylakeavx-*-*]])
 
 dnl  GMP_FAT_SUFFIX(DSTVAR, DIRECTORY)
 dnl  ---------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -1097,7 +1097,11 @@ case $host in
         gcc_cflags_cpu="-mtune=corei7 -mtune=core2 -mtune=nocona -mtune=pentium3 -mcpu=pentiumpro -mcpu=i486 -m486"
         gcc_cflags_arch="-march=corei7 -march=core2 -march=nocona -march=pentium3 -march=pentiumpro -march=pentium"
         ;;
-      sandybridge | ivybridge | haswell)
+      haswell)
+        gcc_cflags_cpu="-mtune=corei7 -mtune=corei7 -mtune=core2 -mtune=nocona -mtune=pentium3 -mcpu=pentiumpro -mcpu=i486 -m486"
+        gcc_cflags_arch="-march=corei7 -march=corei7 -march=core2 -march=nocona -march=pentium3 -march=pentiumpro -march=pentium"
+        ;;
+      sandybridge | ivybridge | haswellavx)
         gcc_cflags_cpu="-mtune=corei7-avx -mtune=corei7 -mtune=core2 -mtune=nocona -mtune=pentium3 -mcpu=pentiumpro -mcpu=i486 -m486"
         gcc_cflags_arch="-march=corei7-avx -march=corei7 -march=core2 -march=nocona -march=pentium3 -march=pentiumpro -march=pentium"
         ;;
@@ -1136,7 +1140,7 @@ case $host in
       k8 | bobcat)		path="x86/k7/mmx/k8 x86/k7/mmx x86/k7 x86" ;;
       core2 | penryn)		path="x86/core2 x86" ;;
       i786 | pentium4)		path="x86/pentium4/sse2 x86/pentium4/mmx x86/pentium4 x86" ;;
-      nehalem | westmere | sandybridge | ivybridge | haswell | skylake | skylakeavx | broadwell)	path="x86/nehalem x86" ;;
+      nehalem | westmere | sandybridge | ivybridge | haswell | haswellavx | skylake | skylakeavx | broadwell)	path="x86/nehalem x86" ;;
       prescott | netburst | netburstlahf)       path="x86/pentium4/sse2 x86/pentium4/mmx x86/pentium4 x86" ;;
       # VIA/Centaur processors, sold as CyrixIII and C3.
       nano | viac32)           path="x86/p6/p3mmx x86/p6/mmx x86/p6 x86";;
@@ -1237,10 +1241,12 @@ case $host in
             path_64="x86_64w/sandybridge/ivybridge x86_64w/sandybridge x86_64w" ;;
           haswell-pc-msys|haswell-w64-mingw*|haswell-*-cygwin*)
             path_64="x86_64w/haswell x86_64w/sandybridge x86_64w" ;;
+          haswellavx-pc-msys|haswellavx-w64-mingw*|haswellavx-*-cygwin*)
+            path_64="x86_64w/haswell/avx x86_64w/haswell x86_64w/sandybridge x86_64w" ;;
           skylake-pc-msys|skylake-w64-mingw*|skylake-*-cygwin*)
             path_64="x86_64w/skylake x86_64w/sandybridge x86_64w" ;;
           skylakeavx-pc-msys|skylakeavx-w64-mingw*|skylakeavx-*-cygwin*)
-            path_64="x86_64w/skylakeavx x86_64w/skylake x86_64w/haswell x86_64w/sandybridge x86_64w" ;;
+            path_64="x86_64w/skylake/avx x86_64w/skylake x86_64w/haswell x86_64w/sandybridge x86_64w" ;;
           broadwell-pc-msys|broadwell-w64-mingw*|broadwell-*-cygwin*)
             path_64="x86_64w/haswell/broadwell x86_64w/haswell/avx x86_64w/haswell x86_64w/sandybridge x86_64w" ;;
           atom-pc-msys|atom-w64-mingw*|atom-*-cygwin*)
@@ -1281,6 +1287,8 @@ case $host in
           ivybridge-*-*)
             path_64="x86_64/sandybridge/ivybridge x86_64/sandybridge x86_64/nehalem x86_64/core2 x86_64" ;;
           haswell-*-*)
+            path_64="x86_64/haswell x86_64/sandybridge x86_64" ;;
+          haswellavx-*-*)
             path_64="x86_64/haswell/avx x86_64/haswell x86_64/sandybridge x86_64" ;;
           broadwell-*-*)
             path_64="x86_64/haswell/broadwell x86_64/haswell/avx x86_64/haswell x86_64/sandybridge x86_64" ;;

--- a/cpuid.c
+++ b/cpuid.c
@@ -174,12 +174,16 @@ CPUVEC_SETUP_x86_64;
 	  if (model == 54){ CPUIS(atom);break;}//DualCore Intel Atom D2700, 2133 MHz (16 x 133) (Cedarview, Saltwell core) 32nm
 	  if (model == 55){ CPUIS(atom);break;}
           if (model == 58){ CPUIS(ivybridge);break;}
-	  if (model == 60){ CPUIS(haswell);break;}
+	  if (model == 60){
+          int feat = ((int *)features)[2];
+          if (feat & FEAT_HAS_AVX) { CPUIS(haswellavx);break; } /* Core i Haswell */
+          else { CPUIS(haswell);break; } /* Celeron/Pentium Haswell without AVX */
+      }
           if (model == 61){ CPUIS(broadwell);break;}
           if (model == 62){ CPUIS(ivybridge);break;}
-          if (model == 63){ CPUIS(haswell);break;}
-          if (model == 69){ CPUIS(haswell);break;}
-          if (model == 70){ CPUIS(haswell);break;}
+          if (model == 63){ CPUIS(haswellavx);break;}
+          if (model == 69){ CPUIS(haswellavx);break;}
+          if (model == 70){ CPUIS(haswellavx);break;}
           if (model == 71){ CPUIS(broadwell);break;}
           if (model == 78){ CPUIS(skylakeavx);break;}
           if (model == 79){ CPUIS(broadwell);break;}

--- a/mpn/x86/fat/fat.c
+++ b/mpn/x86/fat/fat.c
@@ -109,6 +109,7 @@ struct cpuvec_t __gmpn_cpuvec = {
 #define CPUSETUP_sandybridge	CPUVEC_SETUP_nehalem
 #define CPUSETUP_ivybridge	CPUVEC_SETUP_nehalem
 #define CPUSETUP_haswell	CPUVEC_SETUP_nehalem
+#define CPUSETUP_haswellavx	CPUVEC_SETUP_nehalem
 #define CPUSETUP_broadwell      CPUVEC_SETUP_nehalem
 #define CPUSETUP_skylake        CPUVEC_SETUP_nehalem
 #define CPUSETUP_skylakeavx     CPUVEC_SETUP_nehalem

--- a/mpn/x86_64/fat/fat.c
+++ b/mpn/x86_64/fat/fat.c
@@ -103,6 +103,7 @@ struct cpuvec_t __gmpn_cpuvec = {
 #define CPUSETUP_sandybridge	CPUVEC_SETUP_sandybridge
 #define CPUSETUP_ivybridge	CPUVEC_SETUP_sandybridge;CPUVEC_SETUP_sandybridge_ivybridge
 #define CPUSETUP_haswell	CPUVEC_SETUP_haswell
+#define CPUSETUP_haswellavx	CPUVEC_SETUP_haswell;CPUVEC_SETUP_haswell_avx
 #define CPUSETUP_broadwell      CPUVEC_SETUP_haswell;CPUVEC_SETUP_haswell_broadwell
 #define CPUSETUP_skylake        CPUVEC_SETUP_skylake
 #define CPUSETUP_skylakeavx     CPUVEC_SETUP_skylake;CPUVEC_SETUP_skylake_avx

--- a/mpn/x86_64w/fat/fat.c
+++ b/mpn/x86_64w/fat/fat.c
@@ -103,6 +103,7 @@ struct cpuvec_t __gmpn_cpuvec = {
 #define CPUSETUP_sandybridge	CPUVEC_SETUP_sandybridge
 #define CPUSETUP_ivybridge	CPUVEC_SETUP_sandybridge
 #define CPUSETUP_haswell        CPUVEC_SETUP_haswell
+#define CPUSETUP_haswellavx        CPUVEC_SETUP_haswell;CPUVEC_SETUP_haswell_avx
 #define CPUSETUP_broadwell      CPUVEC_SETUP_haswell;CPUVEC_SETUP_haswell_broadwell
 #define CPUSETUP_skylake        CPUVEC_SETUP_skylake
 #define CPUSETUP_skylakeavx     CPUVEC_SETUP_skylake;CPUVEC_SETUP_skylake_avx


### PR DESCRIPTION
Some Haswell CPUs--particularly Pentium/Celeron-branded CPUs that use the Haswell architecture--do not have AVX instruction sets (if I had to guess it's in the silicon but just not enabled), as well as some other instruction sets that seem to go hand-in-hand with whether or not they have AVX.

This splits haswell builds into separate haswell and haswellavx builds, just following the pattern as was done for skylake.  Fixes #209.

I've tested both haswell and haswellavx builds, but I'd like to get confirmation from the original reporter of the issue that this works for them as well.