### PR TITLE
Make mpz_divexact_gcd available in public

### DIFF
--- a/gmp-h.in
+++ b/gmp-h.in
@@ -811,6 +811,9 @@ __GMP_DECLSPEC void mpz_divexact(mpz_ptr, mpz_srcptr, mpz_srcptr);
 #define mpz_divexact_ui __gmpz_divexact_ui
 __GMP_DECLSPEC void mpz_divexact_ui(mpz_ptr, mpz_srcptr, mpir_ui);
 
+#define mpz_divexact_gcd  __gmpz_divexact_gcd
+__GMP_DECLSPEC void mpz_divexact_gcd(mpz_ptr q, mpz_srcptr a, mpz_srcptr d);
+
 #define mpz_divisible_p __gmpz_divisible_p
 __GMP_DECLSPEC int mpz_divisible_p(mpz_srcptr, mpz_srcptr) __GMP_ATTRIBUTE_PURE;
 

--- a/gmp-impl.h
+++ b/gmp-impl.h
@@ -1541,9 +1541,6 @@ __GMP_DECLSPEC int mpn_mulmod_Bexpp1_fft(mp_ptr op, mp_size_t pl,
 /* #define mpn_tdiv_q  __MPN(tdiv_q) */
 /* void mpn_tdiv_q(mp_ptr, mp_size_t, mp_srcptr, mp_size_t, mp_srcptr, mp_size_t); */
 
-#define mpz_divexact_gcd  __gmpz_divexact_gcd
-__GMP_DECLSPEC void mpz_divexact_gcd(mpz_ptr q, mpz_srcptr a, mpz_srcptr d);
-
 #define mpz_prodlimbs  __gmpz_prodlimbs
 __GMP_DECLSPEC mp_size_t mpz_prodlimbs (mpz_ptr, mp_ptr, mp_size_t);
 


### PR DESCRIPTION
Used it in some project, saved me a couple of thousands of tacts. Consider making it public?