### PR TITLE
missing part of #257 - removing vc-directories from dist target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,7 +109,7 @@ EXTRA_DIST = configfsf.guess configfsf.sub .gdbinit INSTALL.autoconf
 if WANT_CXX
 GMPXX_HEADERS_OPTION = mpirxx.h
 endif
-EXTRA_DIST += mpirxx.h yasm_macwin.inc.fat yasm_macwin.inc.nofat yasm_mac.inc.fat yasm_mac.inc.nofat strip_fPIC.sh mpn/x86w mpn/x86_64w build.vc11 build.vc12 build.vc14 build.vc15 build.vc mpir.net doc/devel doc/fdl.texi cpuid.c gpl-2.0.txt lgpl-2.1.txt
+EXTRA_DIST += mpirxx.h yasm_macwin.inc.fat yasm_macwin.inc.nofat yasm_mac.inc.fat yasm_mac.inc.nofat strip_fPIC.sh mpn/x86w mpn/x86_64w mpir.net doc/devel doc/fdl.texi cpuid.c gpl-2.0.txt lgpl-2.1.txt
 
 # mpir.h is architecture dependent, mainly since they encode the
 # limb size used in libmpir.  For that reason they belong under $exec_prefix


### PR DESCRIPTION
While I still would prefer the windows builds to not be organized in a different repo this PR removes the "missing by design" directories from the dist target (which was broken since #257 / August 2018).

Obviously this commit should *not* be applied to the win32 fork.