### PR TITLE
AppVeyor build update (upload artifacts, cache yasm)

### DIFF
--- a/.appveyor_msys_build.sh
+++ b/.appveyor_msys_build.sh
@@ -1,6 +1,15 @@
 export PATH=/c/msys64/mingw$ABI/bin:/c/projects/mpir/bin/:$PATH
 cd /c/projects/mpir
+echo && echo build: ./autogen.sh
 ./autogen.sh
+echo && echo build: ./configure ABI=$ABI $LIB
 ./configure ABI=$ABI $LIB
+echo && echo build: make
 make
+# should work but falsely requires texlive ?!?
+#echo && echo build: DISTCHECK_CONFIGURE_FLAGS="ABI=$ABI $LIB" make distcheck
+#DISTCHECK_CONFIGURE_FLAGS="ABI=$ABI $LIB" make distcheck
+echo && echo build: make check
 make check
+echo && echo build: make dist
+make dist

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ build:
   verbosity: minimal
   
 environment:
+  YASM_BINARY: yasm-1.3.0-win64.exe
+  YASM_DOWNLOAD: http://www.tortall.net/projects/yasm/releases/%YASM_BINARY%
+  MINGW_PREREQ: zip lzip
   matrix:
     - COMPILER: MinGW-w64
       ABI: 32
@@ -16,8 +19,18 @@ environment:
     - COMPILER: MinGW-w64
       ABI: 64
       LIB: --disable-static --enable-shared
+
+install:
+  - if [%COMPILER%]==[MinGW-w64] C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S %MINGW_PREREQ%"
+  - if not exist "%YASM_BINARY%" appveyor DownloadFile "%YASM_DOWNLOAD%"
+  - if [%COMPILER%]==[MinGW-w64] mkdir bin && copy "%YASM_BINARY%" bin\yasm.exe 1>NUL
  
 build_script:
-  - if [%COMPILER%]==[MinGW-w64] mkdir bin && cd bin\ && appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -fileName yasm.exe
   - if [%COMPILER%]==[MinGW-w64] C:\msys64\usr\bin\sh.exe --login /c/projects/mpir/.appveyor_msys_build.sh
 
+cache:
+  - '%YASM_BINARY%'
+
+artifacts:
+  - path: mpir-3.*
+    name: source tarball


### PR DESCRIPTION
This PR adds artifacts to the appveyor build, allowing users to get complete source tarballs without running autogen and friends (and needing the involved tools). Results can be investigated at https://ci.appveyor.com/project/GitMensch/mpir/builds/27767340/job/wa4b16v8qx26v0n8/artifacts (as the repo was recreated the last build failed, this can be ignored...)

Note: this also shows a general issue:
* the package still represents itself as 3.0.0, it likely should be something like 3.1.0-dev (within the CI build we could additionally include the build version number in a follow-up-PR after this is solved)
* also found: it uses `AC_REVISION` in configure.ac which is in to include the revision, but has a CVS-substitution in. This should either be replaced by a "counted" revision (the git hash isn't useful here but we could use a script and apply it via .gitattributes) or be deleted
* also found: `make distcheck` doesn't work because it tries to recreate the info file in the VPATH-build (the result from `make dist`) - this looks like an error as it should be up-to-date _before_ the distribution is packaged ["doesn't work" because the appveyor environment misses texlive; cannot be "fixed" because something happens within `make dist` (once this is fixed and the original `make dist` fails I have a workaround...)]

Detailed changes:

.appveyor_msys_build.sh:
* output build commands
* added `make dist` to create artifacts
* deactivated: use DISTCHECK_CONFIGURE_FLAGS to pass used flags for distcheck (--> as comment because it currently doesn't work, so kept make check + make dist)

appveyor.yml:
* added artifacts (TODO: get MPIR version from file instead of current "3.")
* get additional packages via pacman during install stage (lzip,zip) for building artifacts
* moved yasm-download to install stage
* yasm-version is specified in the environment, downloaded via https and cached