### PR TITLE
option to create file with collected test results

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,3 +34,8 @@ cache:
 artifacts:
   - path: mpir-3.*
     name: source tarball
+  - path: tests/testsuite-all.log
+    name: testsuite results
+
+on_failure:
+  - appveyor PushArtifact tests/testsuite-all.log

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -36,3 +36,11 @@ libtests_la_LIBADD = $(libtests_la_DEPENDENCIES) $(top_builddir)/libmpir.la $(LI
 
 check_PROGRAMS = t-bswap t-constants t-count_zeros t-gmpmax t-hightomask t-modlinv t-parity t-popc t-sub 
 TESTS = $(check_PROGRAMS)
+
+TEST_SUITE_ALL_LOG = testsuite-all.log
+
+$(TEST_SUITE_ALL_LOG): $(TEST_SUITE_LOG) $(SUBDIRS)
+	@rm -rf $(TEST_SUITE_ALL_LOG); \
+	list='$(SUBDIRS)'; for subdir in $$list; do \
+	  cat $$subdir/$(TEST_SUITE_LOG) >> $(TEST_SUITE_ALL_LOG) 2>&1; \
+	done


### PR DESCRIPTION
useful for not needing to collect them manually

Note: the separate test-suite.log of each subdirectory already contains possible testsuite failure details (that are collected in the corresponding t-something.log)