### PR TITLE
option to collect test results, adding this as appveyor artifact

### DIFF
--- a/.appveyor_msys_build.sh
+++ b/.appveyor_msys_build.sh
@@ -10,6 +10,6 @@ make
 #echo && echo build: DISTCHECK_CONFIGURE_FLAGS="ABI=$ABI $LIB" make distcheck
 #DISTCHECK_CONFIGURE_FLAGS="ABI=$ABI $LIB" make distcheck
 echo && echo build: make check
-make check
+make check && make -C tests testsuite-all.log
 echo && echo build: make dist
 make dist

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,3 +34,8 @@ cache:
 artifacts:
   - path: mpir-3.*
     name: source tarball
+  - path: tests/testsuite-all.log
+    name: testsuite results
+
+on_failure:
+  - appveyor PushArtifact tests/testsuite-all.log

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -36,3 +36,11 @@ libtests_la_LIBADD = $(libtests_la_DEPENDENCIES) $(top_builddir)/libmpir.la $(LI
 
 check_PROGRAMS = t-bswap t-constants t-count_zeros t-gmpmax t-hightomask t-modlinv t-parity t-popc t-sub 
 TESTS = $(check_PROGRAMS)
+
+TEST_SUITE_ALL_LOG = testsuite-all.log
+
+$(TEST_SUITE_ALL_LOG): $(TEST_SUITE_LOG) $(SUBDIRS)
+	@rm -rf $(TEST_SUITE_ALL_LOG); \
+	list='$(SUBDIRS)'; for subdir in $$list; do \
+	  cat $$subdir/$(TEST_SUITE_LOG) >> $(TEST_SUITE_ALL_LOG) 2>&1; \
+	done


### PR DESCRIPTION
tests/Makefile.am:
* testsuite-all.log: new target (to be use after `make check`) to collect the test results

.appveyor_msys_build.sh:
* run collector after tests

appveyor.yml:
* new artifact for testsuite results (also pushed if build fails)