### PR TITLE
Replace usage of `which` by `command -v`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1743,7 +1743,7 @@ AC_SUBST(CCAS)
 MPIR_AS=""
 if test -z "$with_yasm"; then
   echo "Looking for a system-wide yasm..."
-  MPIR_AS=`which yasm`
+  MPIR_AS=`command -v yasm`
   if test $? -ne 0; then
     AC_MSG_ERROR([no system-wide yasm found])
   fi


### PR DESCRIPTION
To detect if `yasm` is available, configure uses the `which` command, which may not be available. The posix equivalent is `command -v`.

See: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html