### PR TITLE
Convert source files encoded ISO-8859-1 to UTF-8 (except mpir.net)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -952,7 +952,7 @@ MA 02110-1301, USA.
 2004-06-03  Kevin Ryde  <kevin@swox.se>
 
 	* gmp-impl.h (memset): Use a local char* pointer, in case parameter is
-	something else (eg. tune/common.c).  Reported by Emmanuel Thomé.
+	something else (eg. tune/common.c).  Reported by Emmanuel ThomÃ©.
 
 2004-06-01  Kevin Ryde  <kevin@swox.se>
 
@@ -978,7 +978,7 @@ MA 02110-1301, USA.
 
 	* gmp-impl.h (GET_STR_THRESHOLD_LIMIT): Lower outrageous value to 150.
 
-2004-05-21  Niels Möller  <nisse@lysator.liu.se>
+2004-05-21  Niels MÃ¶ller  <nisse@lysator.liu.se>
 
 	* tune/speed.h (SPEED_ROUTINE_MPN_GCD_CALL): Ensure first operand is
 	not smaller than 2nd operand.
@@ -1089,7 +1089,7 @@ MA 02110-1301, USA.
 2004-05-05  Torbjorn Granlund  <tege@swox.com>
 
 	* mpn/generic/mullow_n.c, mpn/generic/mullow_basecase.c: New files
-	(mainly by Niels Möller).
+	(mainly by Niels MÃ¶ller).
 	* configure.in, mpn/Makefile.am: Add them.
 
 	* gmp-impl.h (MULLOW_BASECASE_THRESHOLD, MULLOW_DC_THRESHOLD,
@@ -1219,7 +1219,7 @@ MA 02110-1301, USA.
 
 	* doc/gmp.texi (Reentrancy, Random State Initialization): Note
 	gmp_randinit use of gmp_errno is not thread safe.  Reported by Vincent
-	Lefèvre.
+	LefÃ¨vre.
 
 	* doc/gmp.texi (Random State Initialization): Add index entries for
 	gmp_errno and constants.
@@ -1459,7 +1459,7 @@ MA 02110-1301, USA.
 
 2004-03-01  Torbjorn Granlund  <tege@swox.com>
 
-	With Karl Hasselström:
+	With Karl HasselstrÃ¶m:
 	* mpn/generic/dc_divrem_n.c (mpn_dc_div_2_by_1): New function, with
 	meat from old mpn_dc_divrem_n.  Accept scratch parameter.  Rewrite to
 	avoid a recursive call.
@@ -1526,7 +1526,7 @@ MA 02110-1301, USA.
 	* configure.in (sparc64-*-*bsd*): Amend -m32 setup for ABI=32, so it's
 	not used in ABI=64 on the BSD systems.
 
-2004-02-18  Niels Möller  <nisse@lysator.liu.se>
+2004-02-18  Niels MÃ¶ller  <nisse@lysator.liu.se>
 
 	* tests/mpz/t-gcd.c (gcdext_valid_p): New function.
 	(ref_mpz_gcd): Deleted function.
@@ -1692,7 +1692,7 @@ MA 02110-1301, USA.
 	* configure.in (--with-readline=detect): Check for readline/readline.h
 	and readline/history.h.  Report result of detection.
 
-2004-01-12  Niels Möller  <nisse@lysator.liu.se>
+2004-01-12  Niels MÃ¶ller  <nisse@lysator.liu.se>
 
 	* tests/tests.h: Added refmpn_free_limbs prototype.
 	* tests/refmpn.c (refmpn_free_limbs): New function.
@@ -1851,7 +1851,7 @@ MA 02110-1301, USA.
 
 	* doc/gmp.texi (Integer Logic and Bit Fiddling): Say "bitwise" in
 	mpz_and, mpz_ior and mpz_xor, to avoid any confusion with what C means
-	by "logical".  Reported by Rüdiger Schütz.
+	by "logical".  Reported by RÃ¼diger SchÃ¼tz.
 
 	* gmp-h.in (_GMP_H_HAVE_FILE): Note why defined(EOF) is not good.
 
@@ -2023,7 +2023,7 @@ MA 02110-1301, USA.
 	* mpn/generic/get_str.c (mpn_get_str, POW2_P case):
 	Don't append extra '\0' byte.
 
-2003-12-05  Niels Möller  <niels@lysator.liu.se>
+2003-12-05  Niels MÃ¶ller  <niels@lysator.liu.se>
 
 	* tune/speed.h (mpn_gcd_accel): Added prototype.
 
@@ -2081,12 +2081,12 @@ MA 02110-1301, USA.
 	(Build Options): Add cpu types alphaev7 and amd64.  Update texinfo
 	html cross reference.
 
-2003-11-28  Niels Möller  <nisse@lysator.liu.se>
+2003-11-28  Niels MÃ¶ller  <nisse@lysator.liu.se>
 
 	* mpn/generic/gcd.c (MPN_LEQ_P): Copied macro definition (needed
 	for compilation with --enable-assert).
 
-2003-11-27  Niels Möller  <nisse@lysator.liu.se>
+2003-11-27  Niels MÃ¶ller  <nisse@lysator.liu.se>
 
 	* tests/mpz/t-gcd.c (gcd_values): Moved definition, so that we
 	don't need to forward declare the array.
@@ -2097,12 +2097,12 @@ MA 02110-1301, USA.
 	decrease # of test to 1000.
 	(gcd_values): Remove oversize test case.
 
-2003-11-26  Niels Möller  <niels@lysator.liu.se>
+2003-11-26  Niels MÃ¶ller  <niels@lysator.liu.se>
 
 	* tests/mpz/t-gcd.c (main): Added some tests with non-random
 	input.
 
-2003-11-25  Niels Möller  <nisse@lysator.liu.se>
+2003-11-25  Niels MÃ¶ller  <nisse@lysator.liu.se>
 
 	* gmp-impl.h (MPN_LEQ_P, MPN_EXTRACT_LIMB): New macros.
 
@@ -3177,7 +3177,7 @@ MA 02110-1301, USA.
 
 	* tests/mpz/bit.c (check_single): Correction to a diagnostic print.
 
-2003-07-24  Niels Möller  <nisse@lysator.liu.se>
+2003-07-24  Niels MÃ¶ller  <nisse@lysator.liu.se>
 
 	* mpz/combit.c: New file.
 	* Makefile.am, mpz/Makefile.am: Add it.
@@ -3826,7 +3826,7 @@ MA 02110-1301, USA.
 
 	* Makefile.am: Put gmp.h and mp.h under $(exec_prefix)/include.
 	* gmp.texi (Build Options): Add notes on this.
-	Reported by Vincent Lefèvre.
+	Reported by Vincent LefÃ¨vre.
 
 2003-03-06  Kevin Ryde  <kevin@swox.se>
 

--- a/NEWS
+++ b/NEWS
@@ -583,7 +583,7 @@ Changes between GMP 4.2.1 and MPIR 0.9.0
 
   Speedups:
   * Jason Martin's Core 2 assembly patches
-  * Niels Möhler's GCD patches
+  * Niels MÃ¶hler's GCD patches
   * Pierrick Gaudry's AMD64 assembly patches
   * Tuning flags for P4, Prescott, Nocona and Core 2
 

--- a/doc/devel/projects.html
+++ b/doc/devel/projects.html
@@ -73,7 +73,7 @@ MA 02110-1301, USA.
 	 in having to do more FFTs, but that is a slight total save.  We then
 	 lose in more expensive CRT. <br><br>
 
-         An nearly complete implementation has been done by Tommy Färnqvist.
+         An nearly complete implementation has been done by Tommy FÃ¤rnqvist.
 
     <li> Perhaps consider N-way Toom, N > 3.  See Knuth's Seminumerical
 	 Algorithms for details on the method.  Code implementing it exists.
@@ -134,8 +134,8 @@ MA 02110-1301, USA.
 
 <li> <strong>Faster GCD</strong>
 
-  <p> Work on Schönhage GCD and GCDEXT for large numbers is in progress.
-      Contact Niels Möller if you want to help.
+  <p> Work on SchÃ¶nhage GCD and GCDEXT for large numbers is in progress.
+      Contact Niels MÃ¶ller if you want to help.
 
 
 <li> <strong>Math functions for the mpf layer</strong>

--- a/doc/devel/tasks.html
+++ b/doc/devel/tasks.html
@@ -494,7 +494,7 @@ MA 02110-1301, USA.
      Set <code>ALLOC(var)</code> to 0 to indicate nothing allocated, and let
      <code>_mpz_realloc</code> do the initial alloc.  Set
      <code>z-&gt;_mp_d</code> to a dummy that <code>mpz_get_ui</code> and
-     similar can unconditionally fetch from.  Niels Möller has had a go at
+     similar can unconditionally fetch from.  Niels MÃ¶ller has had a go at
      this.
      <br>
      The advantages of the lazy scheme would be:
@@ -531,7 +531,7 @@ MA 02110-1301, USA.
      if they could share code with the current such functions (which should be
      possible).
 <li> <code>mpz_and_ui</code> etc might be of use sometimes.  Suggested by
-     Niels Möller.
+     Niels MÃ¶ller.
 <li> <code>mpf_set_str</code> and <code>mpf_inp_str</code> could usefully
      accept 0x, 0b etc when base==0.  Perhaps the exponent could default to
      decimal in this case, with a further 0x, 0b etc allowed there.

--- a/mpn/generic/dc_bdiv_q.c
+++ b/mpn/generic/dc_bdiv_q.c
@@ -1,7 +1,7 @@
 /* mpn_dc_bdiv_q -- divide-and-conquer Hensel division with precomputed
    inverse, returning quotient.
 
-   Contributed to the GNU project by Niels Möller and Torbjorn Granlund.
+   Contributed to the GNU project by Niels MÃ¶ller and Torbjorn Granlund.
 
    THE FUNCTIONS IN THIS FILE ARE INTERNAL WITH MUTABLE INTERFACES.  IT IS ONLY
    SAFE TO REACH THEM THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS ALMOST

--- a/mpn/generic/dc_bdiv_qr.c
+++ b/mpn/generic/dc_bdiv_qr.c
@@ -1,7 +1,7 @@
 /* mpn_dc_bdiv_qr -- divide-and-conquer Hensel division with precomputed
    inverse, returning quotient and remainder.
 
-   Contributed to the GNU project by Niels Möller and Torbjorn Granlund.
+   Contributed to the GNU project by Niels MÃ¶ller and Torbjorn Granlund.
 
    THE FUNCTIONS IN THIS FILE ARE INTERNAL WITH MUTABLE INTERFACES.  IT IS ONLY
    SAFE TO REACH THEM THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS ALMOST

--- a/mpn/generic/dc_bdiv_qr_n.c
+++ b/mpn/generic/dc_bdiv_qr_n.c
@@ -1,7 +1,7 @@
 /* mpn_dc_bdiv_qr -- divide-and-conquer Hensel division with precomputed
    inverse, returning quotient and remainder.
 
-   Contributed to the GNU project by Niels Möller and Torbjorn Granlund.
+   Contributed to the GNU project by Niels MÃ¶ller and Torbjorn Granlund.
 
    THE FUNCTIONS IN THIS FILE ARE INTERNAL WITH MUTABLE INTERFACES.  IT IS ONLY
    SAFE TO REACH THEM THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS ALMOST

--- a/mpn/generic/gcd.c
+++ b/mpn/generic/gcd.c
@@ -24,7 +24,7 @@ along with the GNU MP Library.  If not, see http://www.gnu.org/licenses/.  */
 
 /* Uses the HGCD operation described in
 
-     N. Möller, On Schönhage's algorithm and subquadratic integer gcd
+     N. MÃ¶ller, On SchÃ¶nhage's algorithm and subquadratic integer gcd
      computation, Math. Comp. 77 (2008), 589-607.
 
   to reduce inputs until they are of size below GCD_DC_THRESHOLD, and

--- a/mpn/generic/gcdext_1.c
+++ b/mpn/generic/gcdext_1.c
@@ -55,7 +55,7 @@ mpn_gcdext_1 (mp_limb_signed_t *sp, mp_limb_signed_t *tp,
      V = s1 u + s0 v
 
      where U, V are the inputs (without any shared power of two),
-     and the matris has determinant ± 2^{shift}.
+     and the matris has determinant Â± 2^{shift}.
   */
   mp_limb_t s0 = 1;
   mp_limb_t t0 = 0;
@@ -228,7 +228,7 @@ mpn_gcdext_1 (mp_limb_signed_t *sp, mp_limb_signed_t *tp,
   ugh = ug/2 + (ug & 1);
   vgh = vg/2 + (vg & 1);
 
-  /* Now ±2^{shift} g = s0 U - t0 V. Get rid of the power of two, using
+  /* Now Â±2^{shift} g = s0 U - t0 V. Get rid of the power of two, using
      s0 U - t0 V = (s0 + V/g) U - (t0 + U/g) V. */
   for (i = 0; i < shift; i++)
     {

--- a/mpn/generic/matrix22_mul.c
+++ b/mpn/generic/matrix22_mul.c
@@ -1,6 +1,6 @@
 /* matrix22_mul.c.
 
-   Contributed by Niels Möller and Marco Bodrato.
+   Contributed by Niels MÃ¶ller and Marco Bodrato.
 
    THE FUNCTIONS IN THIS FILE ARE INTERNAL WITH MUTABLE INTERFACES.  IT IS ONLY
    SAFE TO REACH THEM THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS ALMOST

--- a/mpn/generic/sb_bdiv_q.c
+++ b/mpn/generic/sb_bdiv_q.c
@@ -1,7 +1,7 @@
 /* mpn_sb_bdiv_q -- schoolbook Hensel division with precomputed inverse,
    returning quotient only.
 
-   Contributed to the GNU project by Niels Möller.
+   Contributed to the GNU project by Niels MÃ¶ller.
 
    THE FUNCTIONS IN THIS FILE ARE INTERNAL FUNCTIONS WITH MUTABLE INTERFACES.
    IT IS ONLY SAFE TO REACH THEM THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS

--- a/mpn/generic/sb_bdiv_qr.c
+++ b/mpn/generic/sb_bdiv_qr.c
@@ -1,7 +1,7 @@
 /* mpn_sb_bdiv_qr -- schoolbook Hensel division with precomputed inverse,
    returning quotient and remainder.
 
-   Contributed to the GNU project by Niels Möller.
+   Contributed to the GNU project by Niels MÃ¶ller.
 
    THE FUNCTIONS IN THIS FILE ARE INTERNAL FUNCTIONS WITH MUTABLE INTERFACES.
    IT IS ONLY SAFE TO REACH THEM THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS

--- a/mpn/generic/sb_div_q.c
+++ b/mpn/generic/sb_div_q.c
@@ -1,4 +1,4 @@
-/* mpn_sb_div_q -- Schoolbook division using the Möller-Granlund 3/2
+/* mpn_sb_div_q -- Schoolbook division using the MÃ¶ller-Granlund 3/2
    division algorithm.
 
    Contributed to the GNU project by Torbjorn Granlund.

--- a/mpn/generic/sb_div_qr.c
+++ b/mpn/generic/sb_div_qr.c
@@ -1,4 +1,4 @@
-/* mpn_sb_div_qr -- Schoolbook division using the Möller-Granlund 3/2
+/* mpn_sb_div_qr -- Schoolbook division using the MÃ¶ller-Granlund 3/2
    division algorithm.
 
    Contributed to the GNU project by Torbjorn Granlund.

--- a/mpn/generic/sb_divappr_q.c
+++ b/mpn/generic/sb_divappr_q.c
@@ -1,4 +1,4 @@
-/* mpn_sb_divappr_q -- Schoolbook division using the Möller-Granlund 3/2
+/* mpn_sb_divappr_q -- Schoolbook division using the MÃ¶ller-Granlund 3/2
    division algorithm, returning approximate quotient.  The quotient returned
    is either correct, or one too large.
 

--- a/mpn/generic/toom_eval_dgr3_pm1.c
+++ b/mpn/generic/toom_eval_dgr3_pm1.c
@@ -1,6 +1,6 @@
 /* mpn_toom_eval_dgr3_pm1 -- Evaluate a degree 3 polynomial in +1 and -1
 
-   Contributed to the GNU project by Niels Möller
+   Contributed to the GNU project by Niels MÃ¶ller
 
    THE FUNCTION IN THIS FILE IS INTERNAL WITH A MUTABLE INTERFACE.  IT IS ONLY
    SAFE TO REACH IT THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS ALMOST

--- a/mpn/generic/toom_eval_dgr3_pm2.c
+++ b/mpn/generic/toom_eval_dgr3_pm2.c
@@ -1,6 +1,6 @@
 /* mpn_toom_eval_dgr3_pm2 -- Evaluate a degree 3 polynomial in +2 and -2
 
-   Contributed to the GNU project by Niels Möller
+   Contributed to the GNU project by Niels MÃ¶ller
 
    THE FUNCTION IN THIS FILE IS INTERNAL WITH A MUTABLE INTERFACE.  IT IS ONLY
    SAFE TO REACH IT THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS ALMOST

--- a/mpn/generic/toom_eval_pm2.c
+++ b/mpn/generic/toom_eval_pm2.c
@@ -1,6 +1,6 @@
 /* mpn_toom_eval_pm2 -- Evaluate a polynomial in +2 and -2
 
-   Contributed to the GNU project by Niels Möller and Marco Bodrato
+   Contributed to the GNU project by Niels MÃ¶ller and Marco Bodrato
 
    THE FUNCTION IN THIS FILE IS INTERNAL WITH A MUTABLE INTERFACE.  IT IS ONLY
    SAFE TO REACH IT THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS ALMOST

--- a/mpn/generic/toom_eval_pm2exp.c
+++ b/mpn/generic/toom_eval_pm2exp.c
@@ -1,6 +1,6 @@
 /* mpn_toom_eval_pm2exp -- Evaluate a polynomial in +2^k and -2^k
 
-   Contributed to the GNU project by Niels Möller
+   Contributed to the GNU project by Niels MÃ¶ller
 
    THE FUNCTION IN THIS FILE IS INTERNAL WITH A MUTABLE INTERFACE.  IT IS ONLY
    SAFE TO REACH IT THROUGH DOCUMENTED INTERFACES.  IN FACT, IT IS ALMOST

--- a/mpn/x86_64w/bulldozer/mul_basecase.asm
+++ b/mpn/x86_64w/bulldozer/mul_basecase.asm
@@ -1,6 +1,6 @@
 ;  AMD64 mpn_mul_basecase optimised for AMD Bulldozer and Piledriver.
 
-;  Contributed to the GNU project by Torbjörn Granlund.
+;  Contributed to the GNU project by TorbjÃ¶rn Granlund.
 
 ;  Copyright 2003-2005, 2007, 2008, 2011-2013 Free Software Foundation, Inc.
 

--- a/mpz/divexact.c
+++ b/mpz/divexact.c
@@ -1,6 +1,6 @@
 /* mpz_divexact -- finds quotient when known that quot * den == num && den != 0.
 
-Contributed to the GNU project by Niels Möller.
+Contributed to the GNU project by Niels MÃ¶ller.
 
 Copyright 1991, 1993, 1994, 1995, 1996, 1997, 1998, 2000, 2001, 2002, 2005,
 2006, 2007, 2009 Free Software Foundation, Inc.


### PR DESCRIPTION
Non-ASCII source files are currently encoded in a mixture of UTF-8 and ISO-8859-1. This PR standardizes on UTF-8, except files in the `mpir.net` directory.