### PR TITLE
set big endian default for ieee_double_extract

### DIFF
--- a/gmp-impl.h
+++ b/gmp-impl.h
@@ -3384,9 +3384,8 @@ union ieee_double_extract
     } s;
   double d;
 };
-#endif
 
-#if HAVE_DOUBLE_IEEE_LITTLE_ENDIAN
+#elif HAVE_DOUBLE_IEEE_LITTLE_ENDIAN
 #define _GMP_IEEE_FLOATS 1
 union ieee_double_extract
 {
@@ -3399,9 +3398,8 @@ union ieee_double_extract
     } s;
   double d;
 };
-#endif
 
-#if HAVE_DOUBLE_IEEE_BIG_ENDIAN
+#else
 #define _GMP_IEEE_FLOATS 1
 union ieee_double_extract
 {


### PR DESCRIPTION
when HAVE_DOUBLE_* is not defined, ieee_double_extract fails to be defined and mpir compilation fails
set a default value of big endian in such case

workaround solution to #278, there is a better way. this is just a tmp workaround for anyone running into the mentioned issue.

cc: @GitMensch 