### PR TITLE
mpir.org web site resold

### DIFF
--- a/README
+++ b/README
@@ -87,7 +87,7 @@ the INSTALL file in this directory.
 
 If you find a bug in the library, please make sure to tell us about it!
 
-You should first check the MPIR web pages at http://www.mpir.org/. There will 
+You should first check the MPIR web pages at https://web.archive.org/web/20220204054313/http://www.mpir.org/. There will 
 be patches for all known serious bugs there.
 
 Report bugs to our development list: http://groups.google.com/group/mpir-devel.  


### PR DESCRIPTION
Updated MPIR web URL: https://web.archive.org/web/20220204054313/http://www.mpir.org/ Remove other references to the resold dominion mpir.org