### PR TITLE
fix configure with gcc-14

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -590,8 +590,8 @@ extern
 __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
 {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
 void f(){static const struct{t1 n;t1 src[9];t1 want[9];}d[]={{1,{0},{1}},};t1 got[9];int i;
-for(i=0;i<1;i++){if(e(got,got,9,d[i].n)==0)h();g(i,d[i].src,d[i].n,got,d[i].want,9);if(d[i].n)h();}}
 void h(){} void g(){}
+for(i=0;i<1;i++){if(e(got,got,9,d[i].n)==0)h();g(i,d[i].src,d[i].n,got,d[i].want,9);if(d[i].n)h();}}
 #else
 int dummy;
 #endif


### PR DESCRIPTION
move function definition above caller to fix compile error

> configure:6438: gcc -m64  conftest.c >&5
> conftest.c: In function 'f':
> conftest.c:13:44: error: implicit declaration of function 'h' [-Wimplicit-function-declaration]